### PR TITLE
ci: add app install + build jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,48 @@ jobs:
         env:
           APP_ID: "app_test"
 
+  app-install:
+    name: App Install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: npm ci
+        working-directory: app
+        run: npm ci
+
+  app-build:
+    name: App Build
+    runs-on: ubuntu-latest
+    needs: app-install
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: npm ci
+        working-directory: app
+        run: npm ci
+
+      - name: Build
+        working-directory: app
+        run: npm run build
+        env:
+          NEXT_PUBLIC_APP_ID: "app_test"
+          NEXT_PUBLIC_VAULT_ADDRESS: "0xDA3cF80dC04F527563a40Ce17A5466d6A05eefBD"
+          WORLD_RP_ID: "rp_test"
+          RP_SIGNING_KEY: "0x0000000000000000000000000000000000000000000000000000000000000001"
+
   integration:
     name: Fork Tests (World Chain)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- **App Install** job: validates `npm ci` succeeds (dependencies resolve)
- **App Build** job: runs `npm run build` with test env vars (catches type errors, missing imports, build failures)
- Node 20, npm cache enabled for speed
- Build depends on install job

## CI Jobs (after merge)
| Job | What |
|-----|------|
| Unit Tests | `forge test` (contracts) |
| Lint | `forge lint` (contracts) |
| Deploy Dry Run | `forge script` simulation |
| **App Install** | `npm ci` (new) |
| **App Build** | `npm run build` (new) |
| Fork Tests | Integration tests vs live World Chain |

🤖 Generated with [Claude Code](https://claude.com/claude-code)