### PR TITLE
fix: require wallet before deposit to prevent ProofInvalid

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -200,10 +200,12 @@ export default function Terminal() {
     }
 
     if (!MiniKit.isInstalled()) {
-      print(
-        "Error: Open this app inside World App to deposit.",
-        ""
-      );
+      print("Error: Open this app inside World App.", "");
+      return;
+    }
+
+    if (!walletAddress) {
+      print("Connect your wallet first. Tap 'connect wallet' below.", "");
       return;
     }
 
@@ -213,6 +215,7 @@ export default function Terminal() {
         "World ID verification required first — opening IDKit...",
         ""
       );
+      print(`Signal (wallet): ${walletAddress}`);
       setPendingDeposit(amount);
       await openIdkit();
       return;


### PR DESCRIPTION
## Root Cause
`simulation_failed` = `ProofInvalid` on-chain. IDKit was opening with `signal: undefined` because `walletAddress` was null (walletAuth hadn't completed yet). The proof was generated with no signal, but the contract expects `hashToField(msg.sender)`.

## Fix
- Block deposit if `walletAddress` is null — prints "Connect your wallet first"
- Log the signal value before opening IDKit for debugging
- Progressive disclosure (already on main) shows "connect wallet" button first

## Test
After merging: connect wallet → deposit 50 → should see `Signal (wallet): 0x...` → IDKit opens → proof should verify on-chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)