### PR TITLE
fix: add brand assets and metadata to Next.js app

### DIFF
--- a/app/public/app-icon.svg
+++ b/app/public/app-icon.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <!-- CRT Phosphor glow filter -->
+    <filter id="phosphorGlow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="8" result="blur1"/>
+      <feGaussianBlur in="SourceGraphic" stdDeviation="3" result="blur2"/>
+      <feMerge>
+        <feMergeNode in="blur1"/>
+        <feMergeNode in="blur2"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <!-- Stronger outer glow for bloom effect -->
+    <filter id="outerBloom" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" result="bigBlur"/>
+      <feColorMatrix in="bigBlur" type="matrix"
+        values="0 0 0 0 0
+                0 1 0 0 0
+                0 0 0 0 0
+                0 0 0 0.4 0" result="greenBlur"/>
+      <feMerge>
+        <feMergeNode in="greenBlur"/>
+      </feMerge>
+    </filter>
+    <!-- Scanline pattern -->
+    <pattern id="scanlines" patternUnits="userSpaceOnUse" width="512" height="4">
+      <rect width="512" height="2" fill="transparent"/>
+      <rect y="2" width="512" height="2" fill="#000000" opacity="0.08"/>
+    </pattern>
+    <!-- Vignette gradient -->
+    <radialGradient id="vignette" cx="50%" cy="50%" r="60%" fx="50%" fy="50%">
+      <stop offset="0%" stop-color="#0a0a0a" stop-opacity="0"/>
+      <stop offset="70%" stop-color="#0a0a0a" stop-opacity="0"/>
+      <stop offset="100%" stop-color="#000000" stop-opacity="0.6"/>
+    </radialGradient>
+    <!-- Subtle inner screen glow -->
+    <radialGradient id="screenGlow" cx="50%" cy="50%" r="50%" fx="50%" fy="50%">
+      <stop offset="0%" stop-color="#001a00" stop-opacity="1"/>
+      <stop offset="60%" stop-color="#0a0a0a" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#060606" stop-opacity="1"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Background with rounded corners -->
+  <rect width="512" height="512" rx="80" ry="80" fill="#0a0a0a"/>
+
+  <!-- Subtle screen glow in center -->
+  <rect width="512" height="512" rx="80" ry="80" fill="url(#screenGlow)"/>
+
+  <!-- Scanline overlay -->
+  <rect width="512" height="512" rx="80" ry="80" fill="url(#scanlines)"/>
+
+  <!-- Bloom layer (behind text) -->
+  <text x="256" y="295" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace" font-size="160" font-weight="700" fill="#00ff00" filter="url(#outerBloom)">&gt;_</text>
+
+  <!-- Main prompt text with phosphor glow -->
+  <text x="256" y="295" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace" font-size="160" font-weight="700" fill="#00ff00" filter="url(#phosphorGlow)">&gt;_</text>
+
+  <!-- Vignette overlay -->
+  <rect width="512" height="512" rx="80" ry="80" fill="url(#vignette)"/>
+
+  <!-- Blinking cursor animation -->
+  <style>
+    @keyframes blink {
+      0%, 49% { opacity: 1; }
+      50%, 100% { opacity: 0; }
+    }
+    .cursor-blink {
+      animation: blink 1.06s step-end infinite;
+    }
+  </style>
+
+  <!-- Cursor line (blinking overlay on the underscore position) -->
+  <rect class="cursor-blink" x="280" y="300" width="60" height="6" rx="1" fill="#00ff00" filter="url(#phosphorGlow)"/>
+</svg>

--- a/app/public/manifest.json
+++ b/app/public/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Harvest",
+  "short_name": "Harvest",
+  "description": "DeFi, for humans. The first yield aggregator on World Chain.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0a0a0a",
+  "theme_color": "#00ff41",
+  "icons": [
+    {
+      "src": "/app-icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/app/public/og-image.svg
+++ b/app/public/og-image.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <!-- CRT Phosphor glow -->
+    <filter id="ogGlow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="5" result="blur1"/>
+      <feGaussianBlur in="SourceGraphic" stdDeviation="2" result="blur2"/>
+      <feMerge>
+        <feMergeNode in="blur1"/>
+        <feMergeNode in="blur2"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <!-- Heavy bloom for main title -->
+    <filter id="ogBloom" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="16" result="bigBlur"/>
+      <feColorMatrix in="bigBlur" type="matrix"
+        values="0 0 0 0 0
+                0 1 0 0 0
+                0 0 0 0 0
+                0 0 0 0.35 0"/>
+    </filter>
+    <!-- Amber glow -->
+    <filter id="ogAmber" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="3" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <!-- Scanlines -->
+    <pattern id="ogScanlines" patternUnits="userSpaceOnUse" width="1200" height="4">
+      <rect width="1200" height="2" fill="transparent"/>
+      <rect y="2" width="1200" height="2" fill="#000000" opacity="0.07"/>
+    </pattern>
+    <!-- CRT vignette -->
+    <radialGradient id="ogVignette" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#0a0a0a" stop-opacity="0"/>
+      <stop offset="75%" stop-color="#0a0a0a" stop-opacity="0"/>
+      <stop offset="100%" stop-color="#000000" stop-opacity="0.7"/>
+    </radialGradient>
+    <!-- Subtle screen warmth -->
+    <radialGradient id="ogScreenGlow" cx="50%" cy="40%" r="50%">
+      <stop offset="0%" stop-color="#001200" stop-opacity="1"/>
+      <stop offset="50%" stop-color="#0a0a0a" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#050505" stop-opacity="1"/>
+    </radialGradient>
+    <!-- CRT bezel shadow (inner) -->
+    <filter id="innerShadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="15" result="shadow"/>
+      <feOffset dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feFlood flood-color="#000000" flood-opacity="0.5"/>
+      <feComposite in2="SourceAlpha" operator="in"/>
+    </filter>
+  </defs>
+
+  <!-- CRT bezel (outer frame) -->
+  <rect width="1200" height="630" fill="#060606"/>
+
+  <!-- CRT screen area with slight inset -->
+  <rect x="20" y="16" width="1160" height="598" rx="8" ry="8" fill="url(#ogScreenGlow)"/>
+
+  <!-- Scanlines across screen -->
+  <rect x="20" y="16" width="1160" height="598" rx="8" ry="8" fill="url(#ogScanlines)"/>
+
+  <!-- Bloom behind main title -->
+  <text x="600" y="240" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace" font-size="72" font-weight="700" fill="#00ff00" filter="url(#ogBloom)">&gt; harvest_</text>
+
+  <!-- Main title -->
+  <text x="600" y="240" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace" font-size="72" font-weight="700" fill="#00ff00" filter="url(#ogGlow)">&gt; harvest_</text>
+
+  <!-- Tagline in amber -->
+  <text x="600" y="310" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace" font-size="32" font-weight="400" fill="#f5a623" filter="url(#ogAmber)">DeFi, for humans.</text>
+
+  <!-- Subline in dim green -->
+  <text x="600" y="370" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace" font-size="20" font-weight="400" fill="#00aa00">The first yield aggregator on World Chain</text>
+
+  <!-- Horizontal rule -->
+  <line x1="420" y1="410" x2="780" y2="410" stroke="#333333" stroke-width="1"/>
+
+  <!-- Bottom line -->
+  <text x="600" y="450" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace" font-size="14" font-weight="400" fill="#666666">Built at ETHGlobal Cannes 2026</text>
+
+  <!-- CRT vignette overlay -->
+  <rect x="20" y="16" width="1160" height="598" rx="8" ry="8" fill="url(#ogVignette)"/>
+
+  <!-- Top bezel highlight line (simulates glass reflection) -->
+  <line x1="60" y1="20" x2="1140" y2="20" stroke="#1a1a1a" stroke-width="1" opacity="0.5"/>
+</svg>

--- a/app/src/app/icon.svg
+++ b/app/src/app/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- Dark background -->
+  <rect width="32" height="32" rx="6" ry="6" fill="#0a0a0a"/>
+  <!-- >_ prompt, crisp at small size, no glow -->
+  <text x="16" y="22" text-anchor="middle" font-family="'JetBrains Mono', 'SF Mono', 'Fira Code', Menlo, Monaco, 'Courier New', monospace" font-size="16" font-weight="700" fill="#00ff00">&gt;_</text>
+</svg>

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -4,7 +4,28 @@ import { MiniKitProvider } from "./minikit-provider";
 
 export const metadata: Metadata = {
   title: "Harvest",
-  description: "DeFi, for humans. Yield aggregator on World Chain.",
+  description: "DeFi, for humans. The first yield aggregator on World Chain.",
+  manifest: "/manifest.json",
+  icons: {
+    icon: "/icon.svg",
+    apple: "/app-icon.svg",
+  },
+  appleWebApp: {
+    capable: true,
+    title: "Harvest",
+    statusBarStyle: "black-translucent",
+  },
+  openGraph: {
+    title: "Harvest",
+    description: "DeFi, for humans. The first yield aggregator on World Chain.",
+    images: [{ url: "/og-image.svg", width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Harvest",
+    description: "DeFi, for humans. The first yield aggregator on World Chain.",
+    images: ["/og-image.svg"],
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- Copy existing SVG assets (`favicon.svg`, `app-icon.svg`, `og-image.svg`) from `/assets/` into the Next.js app where they can actually be served
- Place `icon.svg` in `app/src/app/` using the Next.js metadata files convention so it is automatically used as the favicon
- Add `app/public/manifest.json` with app name, colors, and icon reference
- Update `layout.tsx` metadata with `icons`, `openGraph`, `twitter`, `appleWebApp`, and `manifest` fields

## Test plan
- [ ] Load the app in a browser and confirm the favicon shows the `>_` prompt icon in the tab
- [ ] Check that `/manifest.json`, `/app-icon.svg`, and `/og-image.svg` are served from the public directory
- [ ] Verify Open Graph tags render correctly when pasting the URL into a social media preview tool
- [ ] Confirm no changes to terminal UI or page.tsx functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)