### PR TITLE
fix: add Multicall3 address to fix portfolio 500 error

### DIFF
--- a/app/src/app/api/balances/route.ts
+++ b/app/src/app/api/balances/route.ts
@@ -5,7 +5,13 @@ import { createPublicClient, http } from "viem";
 const RPC_URL = process.env.RPC_URL || "https://worldchain.drpc.org";
 
 const client = createPublicClient({
-  chain: { id: 480, name: "World Chain", nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 }, rpcUrls: { default: { http: [RPC_URL] } } },
+  chain: {
+    id: 480,
+    name: "World Chain",
+    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    rpcUrls: { default: { http: [RPC_URL] } },
+    contracts: { multicall3: { address: "0xcA11bde05977b3631167028862bE2a173976CA11" } },
+  },
   transport: http(RPC_URL),
 });
 


### PR DESCRIPTION
## Summary
- The `portfolio` command and all balance fetching returned "Error loading portfolio" (HTTP 500)
- Root cause: viem's `multicall` requires the Multicall3 contract address in the chain definition, but our custom World Chain object omitted it
- Multicall3 is deployed on World Chain at the standard address `0xcA11bde05977b3631167028862bE2a173976CA11`

## Test plan
- [ ] `curl http://localhost:3000/api/balances` returns JSON (not 500)
- [ ] `curl "http://localhost:3000/api/balances?wallet=0x..."` returns balances
- [ ] Clicking "portfolio" in the app shows wallet balances

🤖 Generated with [Claude Code](https://claude.com/claude-code)