### PR TITLE
feat: TransparentUpgradeableProxy + _disableInitializers for vault, strategy, swapper

### DIFF
--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -88,8 +88,8 @@ contract Deploy is Script {
         });
 
         HarvestDeployer.DeployParams memory params = HarvestDeployer.DeployParams({
-            vaultName: "Moo World Morpho USDC",
-            vaultSymbol: "mooWorldMorphoUSDC",
+            vaultName: "Harvest World Morpho USDC",
+            vaultSymbol: "harvestWorldMorphoUSDC",
             harvestOnDeposit: true,
             rewards: rewards
         });

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.28;
 
 import {Script, console} from "forge-std/Script.sol";
 import {stdJson} from "forge-std/StdJson.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin-4/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin-4/contracts/proxy/transparent/ProxyAdmin.sol";
 import {HarvestDeployer} from "./deployers/HarvestDeployer.sol";
 import {BeefySwapper} from "../src/BeefySwapper.sol";
 
@@ -45,12 +47,21 @@ contract Deploy is Script {
 
         vm.startBroadcast();
 
-        // ── 1. Deploy BeefySwapper ──────────────────────────────────────────
-        // No oracle needed — strategy always calls swap(from, to, amount, 0)
-        BeefySwapper swapper = new BeefySwapper();
-        swapper.initialize(address(0), 0);
+        // ── 1. Deploy ProxyAdmin (owns all proxies — transfer to multisig post-hackathon) ──
+        ProxyAdmin proxyAdmin = new ProxyAdmin();
 
-        // ── 2. Configure Uniswap V3 swap routes ────────────────────────────
+        // ── 2. Deploy BeefySwapper behind a proxy ────────────────────────────���─
+        // No oracle needed — strategy always calls swap(from, to, amount, 0)
+        BeefySwapper swapperImpl = new BeefySwapper();
+        BeefySwapper swapper = BeefySwapper(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(swapperImpl), address(proxyAdmin), abi.encodeCall(BeefySwapper.initialize, (address(0), 0))
+                )
+            )
+        );
+
+        // ── 3. Configure Uniswap V3 swap routes ────────────────────────────────
         //
         // exactInputSingle calldata layout (228 bytes):
         //   [0:4]     selector 0x04e45aaf
@@ -65,7 +76,7 @@ contract Deploy is Script {
         _setUniV3Route(swapper, uniV3Router, wld, weth, 3000); // 0.3% — WLD/WETH pool has liquidity
         _setUniV3Route(swapper, uniV3Router, weth, usdc, 500); // 0.05% — WETH/USDC pool has liquidity
 
-        // ── 3. Deploy vault + strategy ──────────────────────────────────────
+        // ── 4. Deploy vault + strategy behind proxies ──────────────────────────
         HarvestDeployer.ExternalAddresses memory ext = HarvestDeployer.ExternalAddresses({
             want: usdc,
             depositToken: address(0),
@@ -83,10 +94,11 @@ contract Deploy is Script {
             rewards: rewards
         });
 
-        HarvestDeployer.Deployment memory d = HarvestDeployer.deploy(ext, params);
+        HarvestDeployer.Deployment memory d = HarvestDeployer.deploy(ext, params, address(proxyAdmin));
 
         vm.stopBroadcast();
 
+        console.log("ProxyAdmin:       ", address(proxyAdmin));
         console.log("BeefySwapper:     ", address(swapper));
         console.log("Vault:            ", address(d.vault));
         console.log("Strategy:         ", address(d.strategy));

--- a/contracts/script/VerifyDeployment.s.sol
+++ b/contracts/script/VerifyDeployment.s.sol
@@ -2,6 +2,9 @@
 pragma solidity 0.8.28;
 
 import {Script, console} from "forge-std/Script.sol";
+import {
+    ITransparentUpgradeableProxy
+} from "@openzeppelin-4/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import {BeefyVaultV7} from "../src/BeefyVaultV7.sol";
 import {StrategyMorphoMerkl} from "../src/StrategyMorphoMerkl.sol";
@@ -10,11 +13,16 @@ import {BeefySwapper} from "../src/BeefySwapper.sol";
 /// @notice Post-deployment verification script.
 ///         Run: forge script script/VerifyDeployment.s.sol --rpc-url https://worldchain.drpc.org -vvv
 contract VerifyDeployment is Script {
-    // ── Deployed Harvest contracts ───────────────────────────────────────────
+    // ── Deployed Harvest contracts (proxies) ─────────────────────────────────
+    // Update these addresses after each deployment.
     BeefyVaultV7 internal constant VAULT = BeefyVaultV7(0xDA3cF80dC04F527563a40Ce17A5466d6A05eefBD);
     StrategyMorphoMerkl internal constant STRATEGY =
         StrategyMorphoMerkl(payable(0xd2753e1Ce625A776A4d73f0251419Ba5Dfc1c0A5));
     BeefySwapper internal constant SWAPPER = BeefySwapper(0xe770BD40b6976Efbbb095174395DD2cb794c938a);
+
+    // ── Deployed ProxyAdmin ───────────────────────────────────────────────────
+    // Update this address after each deployment.
+    address internal constant PROXY_ADMIN = address(0); // TODO: set after deploy
 
     // ── Expected external addresses ──────────────────────────────────────────
     address internal constant USDC = 0x79A02482A880bCE3F13e09Da970dC34db4CD24d1;
@@ -32,6 +40,7 @@ contract VerifyDeployment is Script {
         console.log("");
 
         _verifyContracts();
+        _verifyProxies();
         _verifyVault();
         _verifyStrategy();
         _verifySwapper();
@@ -46,6 +55,34 @@ contract VerifyDeployment is Script {
         _check("Vault has code", address(VAULT).code.length > 0);
         _check("Strategy has code", address(STRATEGY).code.length > 0);
         _check("Swapper has code", address(SWAPPER).code.length > 0);
+        console.log("");
+    }
+
+    function _verifyProxies() internal view {
+        console.log("[PROXIES]");
+
+        address vaultImpl = ITransparentUpgradeableProxy(address(VAULT)).implementation();
+        address stratImpl = ITransparentUpgradeableProxy(address(STRATEGY)).implementation();
+        address swapperImpl = ITransparentUpgradeableProxy(address(SWAPPER)).implementation();
+        address vaultAdmin = ITransparentUpgradeableProxy(address(VAULT)).admin();
+        address stratAdmin = ITransparentUpgradeableProxy(address(STRATEGY)).admin();
+        address swapperAdmin = ITransparentUpgradeableProxy(address(SWAPPER)).admin();
+
+        // Implementations must be non-zero (proxies point somewhere)
+        _check("vault proxy has implementation", vaultImpl != address(0));
+        _check("strategy proxy has implementation", stratImpl != address(0));
+        _check("swapper proxy has implementation", swapperImpl != address(0));
+
+        // All three proxies must share the same ProxyAdmin
+        _check("vault admin == PROXY_ADMIN", PROXY_ADMIN == address(0) || vaultAdmin == PROXY_ADMIN);
+        _check("strategy admin == PROXY_ADMIN", PROXY_ADMIN == address(0) || stratAdmin == PROXY_ADMIN);
+        _check("swapper admin == PROXY_ADMIN", PROXY_ADMIN == address(0) || swapperAdmin == PROXY_ADMIN);
+        _check("all proxies share same admin", vaultAdmin == stratAdmin && stratAdmin == swapperAdmin);
+
+        console.log("  vault impl:    ", vaultImpl);
+        console.log("  strategy impl: ", stratImpl);
+        console.log("  swapper impl:  ", swapperImpl);
+        console.log("  proxy admin:   ", vaultAdmin);
         console.log("");
     }
 

--- a/contracts/script/deployers/HarvestDeployer.sol
+++ b/contracts/script/deployers/HarvestDeployer.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
+import {TransparentUpgradeableProxy} from "@openzeppelin-4/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
 import {BeefyVaultV7} from "../../src/BeefyVaultV7.sol";
 import {StrategyMorphoMerkl} from "../../src/StrategyMorphoMerkl.sol";
 import {BaseAllToNativeFactoryStrat} from "../../src/BaseAllToNativeFactoryStrat.sol";
@@ -29,14 +31,21 @@ library HarvestDeployer {
         StrategyMorphoMerkl strategy;
     }
 
-    function deploy(ExternalAddresses memory ext, DeployParams memory params) internal returns (Deployment memory d) {
-        // 1. Deploy vault (uninitialized — no strategy yet)
-        d.vault = new BeefyVaultV7();
+    /// @param proxyAdmin Address that controls proxy upgrades (EOA in tests, ProxyAdmin contract in prod).
+    function deploy(ExternalAddresses memory ext, DeployParams memory params, address proxyAdmin)
+        internal
+        returns (Deployment memory d)
+    {
+        // 1. Deploy logic contracts (initializers disabled — cannot be called directly)
+        BeefyVaultV7 vaultImpl = new BeefyVaultV7();
+        StrategyMorphoMerkl stratImpl = new StrategyMorphoMerkl();
 
-        // 2. Deploy strategy
-        d.strategy = new StrategyMorphoMerkl();
+        // 2. Deploy proxies with no init data so both addresses are known before either is initialized.
+        //    This resolves the chicken-and-egg: strategy needs vault address; vault needs strategy address.
+        d.vault = BeefyVaultV7(address(new TransparentUpgradeableProxy(address(vaultImpl), proxyAdmin, "")));
+        d.strategy = StrategyMorphoMerkl(payable(new TransparentUpgradeableProxy(address(stratImpl), proxyAdmin, "")));
 
-        // 3. Initialize strategy
+        // 3. Initialize strategy (vault proxy address is now known)
         BaseAllToNativeFactoryStrat.Addresses memory addrs = BaseAllToNativeFactoryStrat.Addresses({
             want: ext.want,
             depositToken: ext.depositToken,
@@ -47,7 +56,7 @@ library HarvestDeployer {
         });
         d.strategy.initialize(ext.morphoVault, ext.claimer, params.harvestOnDeposit, params.rewards, addrs);
 
-        // 4. Initialize vault
+        // 4. Initialize vault (strategy proxy address is now known)
         d.vault.initialize(IStrategyV7(address(d.strategy)), params.vaultName, params.vaultSymbol);
     }
 }

--- a/contracts/src/BaseAllToNativeFactoryStrat.sol
+++ b/contracts/src/BaseAllToNativeFactoryStrat.sol
@@ -11,6 +11,11 @@ import {IWrappedNative} from "./interfaces/IWrappedNative.sol";
 abstract contract BaseAllToNativeFactoryStrat is OwnableUpgradeable, PausableUpgradeable {
     using SafeERC20 for IERC20;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     struct Addresses {
         address want;
         address depositToken;

--- a/contracts/src/BeefySwapper.sol
+++ b/contracts/src/BeefySwapper.sol
@@ -18,6 +18,11 @@ contract BeefySwapper is OwnableUpgradeable {
     using SafeERC20Upgradeable for IERC20MetadataUpgradeable;
     using BytesLib for bytes;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     /// @dev Price update failed for a token
     error PriceFailed(address token);
 

--- a/contracts/src/BeefyVaultV7.sol
+++ b/contracts/src/BeefyVaultV7.sol
@@ -24,6 +24,11 @@ contract BeefyVaultV7 is ERC20Upgradeable, OwnableUpgradeable, ReentrancyGuardUp
     // The strategy currently in use by the vault.
     IStrategyV7 public strategy;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     // Permit2 for token transfers (World App pre-approves all tokens to this contract)
     IAllowanceTransfer public constant PERMIT2 = IAllowanceTransfer(0x000000000022D473030F116dDEE9F6B43aC78BA3);
 

--- a/contracts/src/BeefyVaultV7.sol
+++ b/contracts/src/BeefyVaultV7.sol
@@ -34,7 +34,7 @@ contract BeefyVaultV7 is ERC20Upgradeable, OwnableUpgradeable, ReentrancyGuardUp
 
     /**
      * @dev Sets the value of {token} to the token that the vault will
-     * hold as underlying value. It initializes the vault's own 'moo' token.
+     * hold as underlying value. It initializes the vault's own 'harvest' token.
      * This token is minted when someone does a deposit. It is burned in order
      * to withdraw the corresponding portion of the underlying assets.
      * @param _strategy the address of the strategy.

--- a/contracts/src/StrategyMorphoMerkl.sol
+++ b/contracts/src/StrategyMorphoMerkl.sol
@@ -11,6 +11,11 @@ contract StrategyMorphoMerkl is BaseAllToNativeFactoryStrat {
     IERC4626 public morphoVault;
     IMerklClaimer public claimer;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     function initialize(
         address _morphoVault,
         address _claimer,

--- a/contracts/test/base/BaseTest.sol
+++ b/contracts/test/base/BaseTest.sol
@@ -92,7 +92,7 @@ abstract contract BaseTest is Test {
         });
 
         HarvestDeployer.DeployParams memory params = HarvestDeployer.DeployParams({
-            vaultName: "Moo Morpho USDC", vaultSymbol: "mooMorphoUSDC", harvestOnDeposit: false, rewards: rewards
+            vaultName: "Harvest Morpho USDC", vaultSymbol: "harvestMorphoUSDC", harvestOnDeposit: false, rewards: rewards
         });
 
         // proxyAdmin is a separate EOA — must differ from owner so owner can call vault/strategy functions.

--- a/contracts/test/base/BaseTest.sol
+++ b/contracts/test/base/BaseTest.sol
@@ -95,9 +95,13 @@ abstract contract BaseTest is Test {
             vaultName: "Moo Morpho USDC", vaultSymbol: "mooMorphoUSDC", harvestOnDeposit: false, rewards: rewards
         });
 
+        // proxyAdmin is a separate EOA — must differ from owner so owner can call vault/strategy functions.
+        // (TransparentUpgradeableProxy blocks implementation calls from the admin address.)
+        address proxyAdmin = makeAddr("proxyAdmin");
+
         // owner becomes msg.sender for all external calls → owner of vault and strategy
         vm.startPrank(owner);
-        HarvestDeployer.Deployment memory d = HarvestDeployer.deploy(ext, params);
+        HarvestDeployer.Deployment memory d = HarvestDeployer.deploy(ext, params, proxyAdmin);
         vm.stopPrank();
 
         vault = d.vault;

--- a/contracts/test/integration/DepositFork.t.sol
+++ b/contracts/test/integration/DepositFork.t.sol
@@ -79,8 +79,8 @@ contract DepositForkTest is Test {
         });
 
         HarvestDeployer.DeployParams memory params = HarvestDeployer.DeployParams({
-            vaultName: "Moo World Morpho USDC",
-            vaultSymbol: "mooWorldMorphoUSDC",
+            vaultName: "Harvest World Morpho USDC",
+            vaultSymbol: "harvestWorldMorphoUSDC",
             harvestOnDeposit: false,
             rewards: rewards
         });

--- a/contracts/test/integration/DepositFork.t.sol
+++ b/contracts/test/integration/DepositFork.t.sol
@@ -85,8 +85,9 @@ contract DepositForkTest is Test {
             rewards: rewards
         });
 
+        address proxyAdmin = makeAddr("proxyAdmin");
         vm.startPrank(owner);
-        HarvestDeployer.Deployment memory d = HarvestDeployer.deploy(ext, params);
+        HarvestDeployer.Deployment memory d = HarvestDeployer.deploy(ext, params, proxyAdmin);
         vm.stopPrank();
 
         vault = d.vault;

--- a/contracts/test/integration/HarvestSwapFork.t.sol
+++ b/contracts/test/integration/HarvestSwapFork.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {IERC20} from "@openzeppelin-4/contracts/token/ERC20/IERC20.sol";
 import {IERC4626} from "@openzeppelin-4/contracts/interfaces/IERC4626.sol";
 import {IAllowanceTransfer} from "@permit2/interfaces/IAllowanceTransfer.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin-4/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import {HarvestDeployer} from "../../script/deployers/HarvestDeployer.sol";
 import {BeefyVaultV7} from "../../src/BeefyVaultV7.sol";
@@ -63,8 +64,15 @@ contract HarvestSwapForkTest is Test {
     // ── Setup helpers (used only when deploying fresh) ────────────────────────
 
     function _deploySwapper() internal {
-        swapper = new BeefySwapper();
-        swapper.initialize(address(0), 0);
+        swapper = BeefySwapper(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(new BeefySwapper()),
+                    makeAddr("proxyAdmin"),
+                    abi.encodeCall(BeefySwapper.initialize, (address(0), 0))
+                )
+            )
+        );
 
         _setUniV3Route(WLD, WETH, 3000);
         _setUniV3Route(WETH, USDC, 500);
@@ -116,7 +124,7 @@ contract HarvestSwapForkTest is Test {
             rewards: rewards
         });
 
-        HarvestDeployer.Deployment memory d = HarvestDeployer.deploy(ext, params);
+        HarvestDeployer.Deployment memory d = HarvestDeployer.deploy(ext, params, makeAddr("proxyAdmin"));
         vault = d.vault;
         strategy = d.strategy;
     }

--- a/contracts/test/integration/HarvestSwapFork.t.sol
+++ b/contracts/test/integration/HarvestSwapFork.t.sol
@@ -118,8 +118,8 @@ contract HarvestSwapForkTest is Test {
         });
 
         HarvestDeployer.DeployParams memory params = HarvestDeployer.DeployParams({
-            vaultName: "Moo World Morpho USDC",
-            vaultSymbol: "mooWorldMorphoUSDC",
+            vaultName: "Harvest World Morpho USDC",
+            vaultSymbol: "harvestWorldMorphoUSDC",
             harvestOnDeposit: false,
             rewards: rewards
         });

--- a/contracts/test/unit/BeefyVaultV7.t.sol
+++ b/contracts/test/unit/BeefyVaultV7.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
+import {TransparentUpgradeableProxy} from "@openzeppelin-4/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
 import {BaseTest} from "../base/BaseTest.sol";
 import {BaseAllToNativeFactoryStrat} from "../../src/BaseAllToNativeFactoryStrat.sol";
 import {MockERC20} from "../mocks/MockERC20.sol";
@@ -141,21 +143,20 @@ contract BeefyVaultV7Test is BaseTest {
         _depositAs(user, 1000e6);
 
         address[] memory noRewards = new address[](0);
+        BaseAllToNativeFactoryStrat.Addresses memory addrs = BaseAllToNativeFactoryStrat.Addresses({
+            want: address(want),
+            depositToken: address(0),
+            vault: address(vault),
+            swapper: address(swapper),
+            strategist: strategist,
+            feeRecipient: feeRecipient
+        });
+        bytes memory initData = abi.encodeCall(
+            StrategyMorphoMerkl.initialize, (address(morphoVault), address(claimer), false, noRewards, addrs)
+        );
         vm.startPrank(owner);
-        StrategyMorphoMerkl newStrat = new StrategyMorphoMerkl();
-        newStrat.initialize(
-            address(morphoVault),
-            address(claimer),
-            false,
-            noRewards,
-            BaseAllToNativeFactoryStrat.Addresses({
-                want: address(want),
-                depositToken: address(0),
-                vault: address(vault),
-                swapper: address(swapper),
-                strategist: strategist,
-                feeRecipient: feeRecipient
-            })
+        StrategyMorphoMerkl newStrat = StrategyMorphoMerkl(
+            payable(new TransparentUpgradeableProxy(address(new StrategyMorphoMerkl()), makeAddr("pa2"), initData))
         );
         vault.setStrategy(IStrategyV7(address(newStrat)));
         vm.stopPrank();

--- a/contracts/test/unit/BeefyVaultV7.t.sol
+++ b/contracts/test/unit/BeefyVaultV7.t.sol
@@ -13,8 +13,8 @@ contract BeefyVaultV7Test is BaseTest {
     // ── Initialization ────────────────────────────────────────────────────────
 
     function test_initialization() public view {
-        assertEq(vault.name(), "Moo Morpho USDC");
-        assertEq(vault.symbol(), "mooMorphoUSDC");
+        assertEq(vault.name(), "Harvest Morpho USDC");
+        assertEq(vault.symbol(), "harvestMorphoUSDC");
         assertEq(address(vault.strategy()), address(strategy));
         assertEq(vault.owner(), owner);
     }


### PR DESCRIPTION
## Summary
- Adds `_disableInitializers()` constructors to `BeefyVaultV7`, `StrategyMorphoMerkl`, `BaseAllToNativeFactoryStrat`, and `BeefySwapper` — closes the unprotected-initializer attack vector on logic contracts
- Deploys all contracts behind `TransparentUpgradeableProxy` with a shared `ProxyAdmin`; users hold proxy addresses only
- Chicken-and-egg solved: `HarvestDeployer` deploys both proxies with empty init data first (getting their addresses), then initializes each in sequence
- `VerifyDeployment.s.sol` adds `_verifyProxies()` which checks impl addresses are non-zero, all proxies share the same admin, and optionally validates against a hardcoded `PROXY_ADMIN` constant

## What changed
| File | Change |
|---|---|
| `src/BeefyVaultV7.sol` | `constructor() { _disableInitializers(); }` |
| `src/StrategyMorphoMerkl.sol` | same |
| `src/BaseAllToNativeFactoryStrat.sol` | same (abstract base) |
| `src/BeefySwapper.sol` | same |
| `script/deployers/HarvestDeployer.sol` | proxy deploy pattern, `proxyAdmin` param |
| `script/Deploy.s.sol` | deploys `ProxyAdmin`, wraps swapper in proxy |
| `script/VerifyDeployment.s.sol` | `_verifyProxies()` check |
| `test/base/BaseTest.sol` | passes `makeAddr("proxyAdmin")` |
| `test/unit/BeefyVaultV7.t.sol` | `test_setStrategy` deploys replacement via proxy |
| `test/integration/*.t.sol` | all deployments go through proxies |

## Test plan
- [x] `forge build` — clean
- [x] `forge test --match-path "test/unit/*"` — 42/42
- [x] `forge test --match-path "test/integration/*"` — 15/15
- [x] `forge lint` — clean
- [x] Deploy script dry run — simulation complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)