### PR TITLE
fix: atomic proxy init in HarvestDeployer + rename Moo → Harvest

### DIFF
--- a/contracts/script/deployers/HarvestDeployer.sol
+++ b/contracts/script/deployers/HarvestDeployer.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {TransparentUpgradeableProxy} from "@openzeppelin-4/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {TransparentUpgradeableProxy} from
+    "@openzeppelin-4/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import {BeefyVaultV7} from "../../src/BeefyVaultV7.sol";
 import {StrategyMorphoMerkl} from "../../src/StrategyMorphoMerkl.sol";
@@ -36,27 +37,44 @@ library HarvestDeployer {
         internal
         returns (Deployment memory d)
     {
-        // 1. Deploy logic contracts (initializers disabled — cannot be called directly)
+        // 1. Deploy implementation contracts (initializers permanently disabled in constructors)
         BeefyVaultV7 vaultImpl = new BeefyVaultV7();
         StrategyMorphoMerkl stratImpl = new StrategyMorphoMerkl();
 
-        // 2. Deploy proxies with no init data so both addresses are known before either is initialized.
-        //    This resolves the chicken-and-egg: strategy needs vault address; vault needs strategy address.
+        // 2. Deploy vault proxy with no init data.
+        //    Vault.initialize needs the strategy proxy address, which doesn't exist yet.
+        //    This is the minimum necessary 2-step init caused by the vault<->strategy circular dep.
         d.vault = BeefyVaultV7(address(new TransparentUpgradeableProxy(address(vaultImpl), proxyAdmin, "")));
-        d.strategy = StrategyMorphoMerkl(payable(new TransparentUpgradeableProxy(address(stratImpl), proxyAdmin, "")));
 
-        // 3. Initialize strategy (vault proxy address is now known)
-        BaseAllToNativeFactoryStrat.Addresses memory addrs = BaseAllToNativeFactoryStrat.Addresses({
-            want: ext.want,
-            depositToken: ext.depositToken,
-            vault: address(d.vault),
-            swapper: ext.swapper,
-            strategist: ext.strategist,
-            feeRecipient: ext.feeRecipient
-        });
-        d.strategy.initialize(ext.morphoVault, ext.claimer, params.harvestOnDeposit, params.rewards, addrs);
+        // 3. Deploy strategy proxy and initialize it atomically in the constructor.
+        //    The vault proxy address is known from step 2, so no circular dep here.
+        d.strategy = StrategyMorphoMerkl(
+            payable(
+                new TransparentUpgradeableProxy(
+                    address(stratImpl),
+                    proxyAdmin,
+                    abi.encodeCall(
+                        StrategyMorphoMerkl.initialize,
+                        (
+                            ext.morphoVault,
+                            ext.claimer,
+                            params.harvestOnDeposit,
+                            params.rewards,
+                            BaseAllToNativeFactoryStrat.Addresses({
+                                want: ext.want,
+                                depositToken: ext.depositToken,
+                                vault: address(d.vault),
+                                swapper: ext.swapper,
+                                strategist: ext.strategist,
+                                feeRecipient: ext.feeRecipient
+                            })
+                        )
+                    )
+                )
+            )
+        );
 
-        // 4. Initialize vault (strategy proxy address is now known)
+        // 4. Initialize vault. Strategy proxy address is now known.
         d.vault.initialize(IStrategyV7(address(d.strategy)), params.vaultName, params.vaultSymbol);
     }
 }


### PR DESCRIPTION
## Summary
- **Proxy init fix**: Strategy proxy is now initialized atomically in its constructor (init data passed directly to `TransparentUpgradeableProxy`). Vault is the only 2-step init, which is the minimum necessary given the vault↔strategy circular dependency — vault proxy must exist first so strategy can know its address, then vault is initialized last with the strategy address.
- **Rename**: vault name/symbol strings updated from `Moo`/`moo` prefix to `Harvest`/`harvest` across deploy script, base test, fork tests, and unit test assertions.

## Proxy deploy order
1. Deploy vault impl + vault proxy (empty init — strategy address unknown)
2. Deploy strategy impl + strategy proxy **with full init data** (vault proxy address is known)
3. `vault.initialize(strategy, name, symbol)` (strategy proxy address is now known)

## Test plan
- [x] `forge build` — clean
- [x] `forge test --match-path "test/unit/*"` — 42/42
- [x] `forge test --match-path "test/integration/*"` — 15/15
- [x] `forge lint` — clean
- [x] Deploy script dry run — simulation complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)