### PR TITLE
fix: Permit2 allowance expiration causing deposit revert

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -374,7 +374,7 @@ export default function Terminal() {
       const approveCalldata = encodeFunctionData({
         abi: PERMIT2_APPROVE_ABI,
         functionName: "approve",
-        args: [USDC_ADDRESS, VAULT_ADDRESS, amountRaw, 0],
+        args: [USDC_ADDRESS, VAULT_ADDRESS, amountRaw, Math.floor(Date.now() / 1000) + 86400],
       });
 
       const depositCalldata = encodeFunctionData({


### PR DESCRIPTION
## Summary
- Deposit was reverting with `AllowanceExpired(0)` from Permit2
- The `approve()` call set expiration to `0` (epoch), meaning the allowance was already expired when the deposit tried to use it
- Changed to `Date.now()/1000 + 86400` (24 hours from now)

## Test plan
- [ ] Deposit USDC via World App — should no longer revert
- [ ] Verify Permit2 approve + vault deposit execute as bundled UserOp

🤖 Generated with [Claude Code](https://claude.com/claude-code)