### PR TITLE
fix: lazy-load IDKit to prevent white screen in World App

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  IDKitRequestWidget,
-  IDKitResult,
-  IDKitErrorCodes,
-  RpContext,
-  orbLegacy,
-} from "@worldcoin/idkit";
+import dynamic from "next/dynamic";
+import type { IDKitResult, IDKitErrorCodes, RpContext } from "@worldcoin/idkit";
 import { MiniKit } from "@worldcoin/minikit-js";
 import { encodeFunctionData } from "viem";
 import { getBalances, getVaultTvl } from "../lib/client";
+
+// Lazy-load IDKit to prevent crashes in World App webview
+const LazyIDKit = dynamic(
+  () => import("../components/idkit-widget"),
+  { ssr: false }
+);
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -623,12 +624,11 @@ export default function Terminal() {
 
       {/* IDKit v4 widget — backend verification only, no on-chain verifyHuman */}
       {rpContext && walletAddress && (
-        <IDKitRequestWidget
-          app_id={APP_ID}
+        <LazyIDKit
+          appId={APP_ID}
           action="verify-human"
-          rp_context={rpContext}
-          allow_legacy_proofs={true}
-          preset={orbLegacy({ signal: walletAddress })}
+          rpContext={rpContext}
+          walletAddress={walletAddress}
           open={idkitOpen}
           onOpenChange={setIdkitOpen}
           handleVerify={handleVerify}

--- a/app/src/components/idkit-widget.tsx
+++ b/app/src/components/idkit-widget.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import {
+  IDKitRequestWidget,
+  type IDKitResult,
+  type IDKitErrorCodes,
+  type RpContext,
+  orbLegacy,
+} from "@worldcoin/idkit";
+
+export default function IDKitWidget({
+  appId,
+  action,
+  rpContext,
+  walletAddress,
+  open,
+  onOpenChange,
+  handleVerify,
+  onSuccess,
+  onError,
+}: {
+  appId: `app_${string}`;
+  action: string;
+  rpContext: RpContext;
+  walletAddress: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  handleVerify: (result: IDKitResult) => Promise<void>;
+  onSuccess: (result: IDKitResult) => void;
+  onError: (errorCode: IDKitErrorCodes) => void;
+}) {
+  return (
+    <IDKitRequestWidget
+      app_id={appId}
+      action={action}
+      rp_context={rpContext}
+      allow_legacy_proofs={true}
+      preset={orbLegacy({ signal: walletAddress })}
+      open={open}
+      onOpenChange={onOpenChange}
+      handleVerify={handleVerify}
+      onSuccess={onSuccess}
+      onError={onError}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- App showed a blank white page with placeholder icon when opened in World App
- Root cause: `@worldcoin/idkit` top-level import crashes in World App's webview, killing React hydration
- Moved IDKit into a dynamically imported wrapper component (`src/components/idkit-widget.tsx`) with `ssr: false`
- Terminal UI now renders independently of IDKit loading

## Test plan
- [ ] Open mini app in World App — terminal UI should render (green on black)
- [ ] Tap "get started" — World ID verification should still work
- [ ] Verify locally: `curl http://localhost:3000` returns terminal HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)