### PR TITLE
fix: set Permit2 expiration to 0 per World docs

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -375,7 +375,7 @@ export default function Terminal() {
       const approveCalldata = encodeFunctionData({
         abi: PERMIT2_APPROVE_ABI,
         functionName: "approve",
-        args: [USDC_ADDRESS, VAULT_ADDRESS, amountRaw, Math.floor(Date.now() / 1000) + 86400],
+        args: [USDC_ADDRESS, VAULT_ADDRESS, amountRaw, 0],
       });
 
       const depositCalldata = encodeFunctionData({


### PR DESCRIPTION
## Summary
- World App rejected the 24h expiration as "deadline too long"
- Per [World docs](https://docs.world.org/mini-apps/commands/send-transaction), expiration should be `0` because MiniKit bundles approve+deposit atomically in one UserOp
- The allowance is consumed immediately in the same tx, so no expiration window is needed

## Test plan
- [ ] Deposit via World App — no "deadline too long" error
- [ ] Approve + deposit execute atomically in one UserOp

🤖 Generated with [Claude Code](https://claude.com/claude-code)