### PR TITLE
fix: Permit2 expiration timestamp, bump v1.6

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -78,7 +78,7 @@ function formatBigintUSDC(raw: bigint): string {
 
 export default function Terminal() {
   const [lines, setLines] = useState<string[]>([
-    "HARVEST v1.4 — Agentic DeFi, for humans.",
+    "HARVEST v1.6 — Agentic DeFi, for humans.",
     "World Chain yield aggregator.",
     "",
   ]);
@@ -372,10 +372,12 @@ export default function Terminal() {
     try {
       const amountRaw = BigInt(Math.floor(amount * 1e6));
 
+      // Permit2 expiration is a uint48 Unix timestamp — 0 means already expired
+      const expiration = Math.floor(Date.now() / 1000) + 60; // 1 minute from now
       const approveCalldata = encodeFunctionData({
         abi: PERMIT2_APPROVE_ABI,
         functionName: "approve",
-        args: [USDC_ADDRESS, VAULT_ADDRESS, amountRaw, 0],
+        args: [USDC_ADDRESS, VAULT_ADDRESS, amountRaw, expiration],
       });
 
       const depositCalldata = encodeFunctionData({


### PR DESCRIPTION
## Summary
- Permit2 `approve()` expiration param is a **uint48 Unix timestamp**, not a duration. Passing `0` means "already expired", causing `PERMIT2.transferFrom()` to revert (`invalid_contract` in MiniKit).
- Set expiration to `now + 60 seconds` so the allowance is valid for the multicall execution window.
- Bump version to v1.6.

## Test plan
- [ ] Open mini app, run `deposit` command — tx should succeed without `invalid_contract` error
- [ ] Verify deposit lands in vault and shares are minted

🤖 Generated with [Claude Code](https://claude.com/claude-code)