### PR TITLE
fix: reduce Permit2 expiration to 15s, bump v1.7

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -78,7 +78,7 @@ function formatBigintUSDC(raw: bigint): string {
 
 export default function Terminal() {
   const [lines, setLines] = useState<string[]>([
-    "HARVEST v1.6 — Agentic DeFi, for humans.",
+    "HARVEST v1.7 — Agentic DeFi, for humans.",
     "World Chain yield aggregator.",
     "",
   ]);
@@ -373,7 +373,7 @@ export default function Terminal() {
       const amountRaw = BigInt(Math.floor(amount * 1e6));
 
       // Permit2 expiration is a uint48 Unix timestamp — 0 means already expired
-      const expiration = Math.floor(Date.now() / 1000) + 60; // 1 minute from now
+      const expiration = Math.floor(Date.now() / 1000) + 15; // 15 seconds from now
       const approveCalldata = encodeFunctionData({
         abi: PERMIT2_APPROVE_ABI,
         functionName: "approve",


### PR DESCRIPTION
## Summary
- Reduce Permit2 allowance expiration from 60s to 15s to tighten the approval window
- Bump version to v1.7

## Test plan
- [ ] Run `deposit` in mini app — verify tx succeeds within 15s window
- [ ] If 15s is too tight for the UserOp bundler, we'll adjust based on permit2 research

🤖 Generated with [Claude Code](https://claude.com/claude-code)