### PR TITLE
fix: Permit2 expiration to current timestamp, bump v1.8

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -78,7 +78,7 @@ function formatBigintUSDC(raw: bigint): string {
 
 export default function Terminal() {
   const [lines, setLines] = useState<string[]>([
-    "HARVEST v1.7 — Agentic DeFi, for humans.",
+    "HARVEST v1.8 — Agentic DeFi, for humans.",
     "World Chain yield aggregator.",
     "",
   ]);
@@ -372,8 +372,8 @@ export default function Terminal() {
     try {
       const amountRaw = BigInt(Math.floor(amount * 1e6));
 
-      // Permit2 expiration is a uint48 Unix timestamp — 0 means already expired
-      const expiration = Math.floor(Date.now() / 1000) + 15; // 15 seconds from now
+      // Permit2: current timestamp, no padding — strict > check means same-second passes
+      const expiration = Math.floor(Date.now() / 1000);
       const approveCalldata = encodeFunctionData({
         abi: PERMIT2_APPROVE_ABI,
         functionName: "approve",


### PR DESCRIPTION
## Summary
- Set Permit2 expiration to `Date.now() / 1000` (current timestamp, no padding)
- Permit2's check is `block.timestamp > expiration` (strict `>`), so same-second passes
- Avoids `permit_deadline_too_long` rejection from World backend (any future padding triggers it)
- Avoids simulation failure from `expiration: 0` 
- Bump version to v1.8

## Test plan
- [ ] Run `deposit` in mini app — verify no `permit_deadline_too_long` or simulation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)