### PR TITLE
fix(app): balance-aware deposit picker

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -89,6 +89,8 @@ export default function Terminal() {
   const [walletAddress, setWalletAddress] = useState<string | null>(null);
   const [isVerified, setIsVerified] = useState(false);
   const [hasShares, setHasShares] = useState(false);
+  const [depositMode, setDepositMode] = useState(false);
+  const [usdcBalance, setUsdcBalance] = useState<bigint>(BigInt(0));
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -164,6 +166,25 @@ export default function Terminal() {
     if (!walletAddress) {
       print("Connect your wallet first. Tap 'get started' below.", "");
       return;
+    }
+
+    // Check balance before proceeding
+    try {
+      const { usdcBalance: bal } = await getBalances(walletAddress);
+      setUsdcBalance(bal);
+      const balanceUSD = Number(bal) / 1e6;
+      if (amount > balanceUSD) {
+        print(
+          `Insufficient balance: you have $${formatUSDC(balanceUSD)} USDC.`,
+          balanceUSD > 0
+            ? `Try 'deposit ${Math.floor(balanceUSD)}' or tap deposit for options.`
+            : "Top up your wallet first.",
+          ""
+        );
+        return;
+      }
+    } catch {
+      // balance check failed — let the tx attempt and fail naturally
     }
 
     if (!isVerified) {
@@ -291,6 +312,36 @@ export default function Terminal() {
   async function handleAgentHarvest() {
     print("Triggering manual harvest...");
     print("No pending rewards above threshold.", "");
+  }
+
+  // ── Deposit picker flow ──────────────────────────────────────────────────────
+
+  async function openDepositPicker() {
+    if (!walletAddress) {
+      print("Connect your wallet first. Tap 'get started'.", "");
+      return;
+    }
+    print("harvest> deposit", "Checking balance...");
+    try {
+      const { usdcBalance: bal } = await getBalances(walletAddress);
+      setUsdcBalance(bal);
+      if (bal === BigInt(0)) {
+        print("No USDC balance. Top up your wallet first.", "");
+        return;
+      }
+      setDepositMode(true);
+      print("Select amount:");
+    } catch {
+      print("Error: Could not fetch balance.", "");
+    }
+  }
+
+  async function onDepositAmount(amount: number | "max") {
+    setDepositMode(false);
+    const resolvedAmount =
+      amount === "max" ? Number(usdcBalance) / 1e6 : amount;
+    print(`  → $${formatUSDC(resolvedAmount)}`);
+    await handleDeposit([resolvedAmount.toString()]);
   }
 
   // ── IDKit flow (backend-only verification) ─────────────────────────────────
@@ -529,19 +580,41 @@ export default function Terminal() {
 
   // ── Contextual shortcut buttons ─────────────────────────────────────────────
 
-  function getButtons(): { label: string; action: () => void }[] {
+  function getButtons(): { label: string; action: () => void; disabled?: boolean }[] {
+    // Deposit amount picker — shown after openDepositPicker() fetches the balance
+    if (depositMode) {
+      const balanceUSD = Number(usdcBalance) / 1e6;
+      return [
+        ...[10, 25, 50, 100].map((amt) => ({
+          label: `$${amt}`,
+          action: () => onDepositAmount(amt),
+          disabled: amt > balanceUSD,
+        })),
+        {
+          label: `MAX ($${formatUSDC(balanceUSD)})`,
+          action: () => onDepositAmount("max"),
+          disabled: false,
+        },
+        {
+          label: "cancel",
+          action: () => { setDepositMode(false); print("Cancelled.", ""); },
+          disabled: false,
+        },
+      ];
+    }
+
     if (!walletAddress || !isVerified) {
       return [{ label: "get started", action: handleGetStarted }];
     }
     if (hasShares) {
       return [
-        { label: "deposit", action: () => handleCommand("deposit 50") },
+        { label: "deposit", action: openDepositPicker },
         { label: "portfolio", action: () => handleCommand("portfolio") },
         { label: "withdraw all", action: () => handleCommand("withdraw all") },
       ];
     }
     return [
-      { label: "deposit", action: () => handleCommand("deposit 50") },
+      { label: "deposit", action: openDepositPicker },
       { label: "portfolio", action: () => handleCommand("portfolio") },
     ];
   }
@@ -584,7 +657,7 @@ export default function Terminal() {
         {getButtons().map((btn) => (
           <button
             key={btn.label}
-            onClick={btn.action}
+            onClick={btn.disabled ? undefined : btn.action}
             style={{
               background: "transparent",
               border: "1px solid #00ff41",
@@ -592,7 +665,8 @@ export default function Terminal() {
               fontFamily: "inherit",
               fontSize: "11px",
               padding: "4px 8px",
-              cursor: "pointer",
+              cursor: btn.disabled ? "default" : "pointer",
+              opacity: btn.disabled ? 0.3 : 1,
             }}
           >
             {btn.label}


### PR DESCRIPTION
## Summary

- Tapping **deposit** now fetches the user's USDC balance before showing the picker
- Preset amounts ($10/$25/$50/$100) are **dimmed and unclickable** if the user can't afford them
- **MAX** shows the actual balance, e.g. `MAX ($0.50)` — always tappable
- If balance is **$0**, shows an error message instead of an empty picker
- `handleDeposit` (text input path) also validates balance upfront and gives a useful error with a suggested amount

## Before / After

Before: tapping deposit → immediately tried `deposit 50` regardless of balance  
After: tapping deposit → fetches balance → shows picker with only affordable options enabled

## Test plan

- [ ] Wallet with $0 USDC → "No USDC balance. Top up your wallet first."
- [ ] Wallet with $0.50 → picker shows `$10` `$25` `$50` `$100` all dimmed, `MAX ($0.50)` enabled
- [ ] Wallet with $30 → `$10` `$25` enabled, `$50` `$100` dimmed, `MAX ($30.00)` enabled
- [ ] Tap MAX → deposits full balance
- [ ] Type `deposit 50` with $0.50 → "Insufficient balance: you have $0.50 USDC."
- [ ] Tap cancel → depositMode closes, "Cancelled." printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)