### PR TITLE
fix: Permit2 expiration now+2s, bump v1.9

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -78,7 +78,7 @@ function formatBigintUSDC(raw: bigint): string {
 
 export default function Terminal() {
   const [lines, setLines] = useState<string[]>([
-    "HARVEST v1.8 — Agentic DeFi, for humans.",
+    "HARVEST v1.9 — Agentic DeFi, for humans.",
     "World Chain yield aggregator.",
     "",
   ]);
@@ -372,8 +372,8 @@ export default function Terminal() {
     try {
       const amountRaw = BigInt(Math.floor(amount * 1e6));
 
-      // Permit2: current timestamp, no padding — strict > check means same-second passes
-      const expiration = Math.floor(Date.now() / 1000);
+      // Permit2: 2s padding — strict > check means same-block passes
+      const expiration = Math.floor(Date.now() / 1000) + 2;
       const approveCalldata = encodeFunctionData({
         abi: PERMIT2_APPROVE_ABI,
         functionName: "approve",


### PR DESCRIPTION
## Summary
- Set Permit2 expiration to `now + 2 seconds`
- Bump version to v1.9

## Failure history
| Expiration | Result |
|-----------|--------|
| `0` | Simulation failure (despite docs recommending 0) |
| `now + 0` | Simulation failure |
| `now + 15` | `permit_deadline_too_long` |
| `now + 60` | `permit_deadline_too_long` |
| **`now + 2`** | **Testing now** |

## Test plan
- [ ] Run `deposit` in mini app — verify tx succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)