### PR TITLE
HELP: Permit2 expiration simulation failure — 7 attempts, all rejected

### DIFF
--- a/docs/permit2-expiration-failures.md
+++ b/docs/permit2-expiration-failures.md
@@ -1,0 +1,223 @@
+# Permit2 Expiration Failures: A History
+
+**Date:** 2026-04-04
+**Status:** Unresolved -- searching for a value that satisfies both Permit2 on-chain logic and World's MiniKit simulation backend
+**Affected file:** `app/src/app/page.tsx` (the `expiration` arg to `Permit2.approve()`)
+
+---
+
+## Background
+
+MiniKit requires all ERC-20 token transfers to go through Permit2 (`0x000000000022D473030F116dDEE9F6B43aC78BA3`). Standard `approve()` calls are blocked. Our deposit flow bundles two calls atomically in a single MiniKit `sendTransaction` UserOp:
+
+1. `Permit2.approve(USDC, vault, amount, expiration)` -- set allowance
+2. `HarvestVault.deposit(amount)` -- vault calls `Permit2.transferFrom()` to pull USDC
+
+The `expiration` parameter to `Permit2.approve()` is a `uint48` Unix timestamp. The problem: every value we have tried either fails Permit2's on-chain check or gets rejected by World's simulation backend before the transaction is ever submitted.
+
+---
+
+## The Contradiction
+
+**Permit2 on-chain** requires that the expiration has not passed at the time `transferFrom()` executes. The check in `AllowanceTransfer.sol` line 79 is:
+
+```solidity
+if (block.timestamp > allowed.expiration) revert AllowanceExpired(allowed.expiration);
+```
+
+This is a **strict greater-than** (`>`), meaning `block.timestamp == expiration` does NOT revert.
+
+When `expiration == 0` is passed to `approve()`, Permit2 treats it as a sentinel value and stores `block.timestamp` instead (see `Allowance.sol` line 24):
+
+```solidity
+uint48 storedExpiration = expiration == BLOCK_TIMESTAMP_EXPIRATION
+    ? uint48(block.timestamp)
+    : expiration;
+```
+
+So `expiration=0` means "valid only for this block." In theory, if `approve()` and `transferFrom()` execute in the same block (which they do in a bundled UserOp), the stored value is `block.timestamp` and the check `block.timestamp > block.timestamp` is `false`, so it should pass.
+
+**World's MiniKit backend** simulates transactions before submitting them. This simulation rejects:
+- `expiration = 0`: simulation fails (the simulation environment apparently evaluates the sentinel differently, or runs approve and transferFrom at different simulated timestamps)
+- Any future timestamp (even `now + 15`): `permit_deadline_too_long` error
+- Current timestamp (`now + 0`): still fails simulation
+
+The result is a **no-win scenario**: the on-chain contract needs a non-expired timestamp, but the simulation backend rejects anything that is not effectively "right now" and also rejects "right now."
+
+---
+
+## Full Timeline of Attempts
+
+### Attempt 1: `expiration = 0` (initial)
+
+| Field | Value |
+|-------|-------|
+| **Commit** | `4418702` feat: functional mini app with deposit, withdraw, portfolio |
+| **PR** | [#34](https://github.com/ElliotFriedman/harvest-world/pull/34) (merged 2026-04-03) |
+| **Value** | `0` (hardcoded) |
+| **Rationale** | World docs say to use 0 for atomic bundled txs. Permit2 treats 0 as sentinel for `block.timestamp`. |
+| **Result** | **Simulation failure** -- MiniKit returns `simulation_failed` before the tx reaches chain. The simulation environment does not handle the `0` sentinel the same way as the on-chain EVM. |
+
+### Attempt 2: `now + 86400` (24 hours)
+
+| Field | Value |
+|-------|-------|
+| **Commit** | `c8afe92` fix: set Permit2 allowance expiration to 24h instead of 0 |
+| **PR** | [#54](https://github.com/ElliotFriedman/harvest-world/pull/54) (merged 2026-04-04 04:08 UTC) |
+| **Value** | `Math.floor(Date.now() / 1000) + 86400` |
+| **Rationale** | Assumed 0 literally meant "already expired." 24h gives ample window. |
+| **Result** | **`permit_deadline_too_long`** -- World's backend rejects expirations too far in the future. The 24h window was flagged as excessive. |
+
+### Attempt 3: `expiration = 0` (reverted back)
+
+| Field | Value |
+|-------|-------|
+| **Commit** | `a29b254` fix: revert Permit2 expiration to 0 per World docs |
+| **PR** | [#56](https://github.com/ElliotFriedman/harvest-world/pull/56) (merged 2026-04-04 04:22 UTC) |
+| **Value** | `0` |
+| **Rationale** | World docs explicitly say expiration should be 0 for atomic bundled ops. Assumed the 24h rejection means they enforce 0. |
+| **Result** | **Simulation failure again** -- same as attempt 1. The docs say 0 but the simulation rejects 0. |
+
+### Attempt 4: `now + 60` (1 minute)
+
+| Field | Value |
+|-------|-------|
+| **Commit** | `eef311a` fix(app): set Permit2 expiration to 1min future timestamp, bump v1.6 |
+| **PR** | [#59](https://github.com/ElliotFriedman/harvest-world/pull/59) (merged 2026-04-04 04:35 UTC) |
+| **Value** | `Math.floor(Date.now() / 1000) + 60` |
+| **Rationale** | Try a small future window. Not too long to trigger deadline rejection, not zero. |
+| **Result** | **`permit_deadline_too_long`** -- even 60 seconds is considered "too long" by the World backend. |
+
+### Attempt 5: `now + 15` (15 seconds)
+
+| Field | Value |
+|-------|-------|
+| **Commit** | `96727b8` fix(app): reduce Permit2 expiration to 15s, bump v1.7 |
+| **PR** | [#60](https://github.com/ElliotFriedman/harvest-world/pull/60) (merged 2026-04-04 04:43 UTC) |
+| **Value** | `Math.floor(Date.now() / 1000) + 15` |
+| **Rationale** | Tighten the window further. 15s should be enough for bundler submission. |
+| **Result** | **`permit_deadline_too_long`** -- World's backend still rejects it. The threshold appears to be very aggressive. |
+
+### Attempt 6: `now + 0` (current timestamp, no padding)
+
+| Field | Value |
+|-------|-------|
+| **Commit** | `6533101` fix(app): use current timestamp for Permit2 expiration, bump v1.8 |
+| **PR** | [#62](https://github.com/ElliotFriedman/harvest-world/pull/62) (merged 2026-04-04 04:53 UTC) |
+| **Value** | `Math.floor(Date.now() / 1000)` |
+| **Rationale** | The strict `>` check means `block.timestamp == expiration` passes. Using current timestamp avoids "too long" rejection while still being non-zero. |
+| **Result** | **Simulation failure** -- World's simulation apparently runs at a timestamp slightly in the future of the client's `Date.now()`, causing `block.timestamp > expiration` to be true in simulation. |
+
+### Attempt 7: `now + 2` (2 seconds, current)
+
+| Field | Value |
+|-------|-------|
+| **Commit** | `0407597` fix(app): set Permit2 expiration to now+2s, bump v1.9 |
+| **Branch** | `fix/permit2-expiration-2s` (current HEAD) |
+| **Value** | `Math.floor(Date.now() / 1000) + 2` |
+| **Rationale** | Split the difference -- 2s padding might survive both the "too long" check and the simulation clock skew. |
+| **Result** | **Pending** -- about to test. |
+
+---
+
+## Permit2 Source Code Analysis
+
+The relevant code lives in `contracts/lib/permit2/src/libraries/Allowance.sol` and `contracts/lib/permit2/src/AllowanceTransfer.sol`.
+
+### Allowance.sol (lines 7-30): The `0` sentinel
+
+```solidity
+// note if the expiration passed is 0, then it the approval set to the block.timestamp
+uint256 private constant BLOCK_TIMESTAMP_EXPIRATION = 0;
+
+function updateAll(..., uint48 expiration, ...) internal {
+    uint48 storedExpiration = expiration == BLOCK_TIMESTAMP_EXPIRATION
+        ? uint48(block.timestamp)
+        : expiration;
+    // ... pack and store
+}
+```
+
+When you call `approve(..., 0)`, Permit2 does NOT store `0`. It stores `block.timestamp`. This is designed for single-block allowances.
+
+### AllowanceTransfer.sol (line 79): The expiry check
+
+```solidity
+if (block.timestamp > allowed.expiration) revert AllowanceExpired(allowed.expiration);
+```
+
+The check is **strict greater-than** (`>`). This means:
+- `block.timestamp == expiration`: PASSES (not expired)
+- `block.timestamp > expiration`: REVERTS
+
+So if `approve()` and `transferFrom()` execute in the same block (which they do in a UserOp bundle), `expiration = 0` should work because:
+1. `approve()` stores `block.timestamp` (e.g., `1712233200`)
+2. `transferFrom()` checks `1712233200 > 1712233200` which is `false`
+3. Check passes, transfer succeeds
+
+### Why it fails in simulation
+
+World's MiniKit simulation environment does not behave identically to the on-chain EVM for this case. Possible explanations:
+
+1. **Simulation runs calls at different simulated timestamps.** If the simulation engine advances `block.timestamp` between the `approve()` and `transferFrom()` calls within the same UserOp, the stored value from step 1 would be stale by step 2.
+
+2. **Simulation uses `block.timestamp = 0` or some default.** If the simulation does not set a realistic `block.timestamp`, then `approve(..., 0)` stores `0`, and ANY nonzero simulated timestamp for `transferFrom()` would cause `0 > 0` ... no, that still passes. But if `block.timestamp` were `1` at transferFrom time, `1 > 0` reverts.
+
+3. **Client-server clock skew.** For non-zero values like `now + 0`, the client's `Date.now()` may be a few seconds behind the simulation server's clock. If the server simulates at `client_now + 3`, then `client_now + 0` is already expired.
+
+4. **The simulation rejects the expiration value itself before simulating.** World's backend may have a validation layer that checks `expiration` independently of Permit2's on-chain logic, applying its own rules about acceptable ranges.
+
+Explanation 4 is the most consistent with the observed behavior: a pre-simulation validation that rejects `0` (because it looks like "no expiration" or "invalid") AND rejects anything more than a few seconds in the future (because "deadline too long"). This would mean the acceptable window is something like `now + 1` to `now + N` where N is very small and undocumented.
+
+---
+
+## Summary of the Constraint Space
+
+```
+Value              On-chain result         World simulation result
+-----------------  ----------------------  --------------------------
+0                  PASS (same-block)       FAIL: simulation_failed
+now + 0            PASS (strict > check)   FAIL: simulation_failed
+now + 2            PASS                    PENDING (attempt 7)
+now + 15           PASS                    FAIL: permit_deadline_too_long
+now + 60           PASS                    FAIL: permit_deadline_too_long
+now + 86400        PASS                    FAIL: permit_deadline_too_long
+```
+
+The on-chain Permit2 contract would accept any of these values. The constraint is entirely from World's simulation/validation layer, which appears to enforce an undocumented acceptable range.
+
+---
+
+## Branches and PRs (quick reference)
+
+| Branch | PR | Commit | Expiration | Merged |
+|--------|----|--------|-----------|--------|
+| `feat/mini-app-functional` | [#34](https://github.com/ElliotFriedman/harvest-world/pull/34) | `4418702` | `0` | Yes |
+| `fix/permit2-expiration` | [#54](https://github.com/ElliotFriedman/harvest-world/pull/54) | `c8afe92` | `now + 86400` | Yes |
+| `fix/permit2-expiration-zero` | [#56](https://github.com/ElliotFriedman/harvest-world/pull/56) | `a29b254` | `0` | Yes |
+| `fix/permit2-expiration-timestamp` | [#59](https://github.com/ElliotFriedman/harvest-world/pull/59) | `eef311a` | `now + 60` | Yes |
+| `fix/permit2-expiration-15s` | [#60](https://github.com/ElliotFriedman/harvest-world/pull/60) | `96727b8` | `now + 15` | Yes |
+| `fix/permit2-current-timestamp` | [#62](https://github.com/ElliotFriedman/harvest-world/pull/62) | `6533101` | `now + 0` | Yes |
+| `fix/permit2-expiration-2s` | -- | `0407597` | `now + 2` | Pending |
+
+---
+
+## Key Source Files
+
+| File | Relevance |
+|------|-----------|
+| `contracts/lib/permit2/src/libraries/Allowance.sol` (lines 7-30) | Sentinel value logic: `0` maps to `block.timestamp` |
+| `contracts/lib/permit2/src/libraries/Allowance.sol` (lines 34-41) | `updateAmountAndExpiration`: same sentinel logic |
+| `contracts/lib/permit2/src/AllowanceTransfer.sol` (line 79) | Expiry check: strict `>` (not `>=`) |
+| `contracts/lib/permit2/src/interfaces/IAllowanceTransfer.sol` (line 12) | `AllowanceExpired(uint256 deadline)` error definition |
+| `app/src/app/page.tsx` (~line 374) | Where expiration is set in the frontend deposit flow |
+
+---
+
+## What Would Fix This
+
+1. **World documents the actual acceptable range.** The docs say `0` but the backend rejects it. If the acceptable range is, say, `now + 1` to `now + 5`, that should be documented.
+
+2. **World's simulation handles the `0` sentinel correctly.** If the simulation engine stored `block.timestamp` for `expiration=0` (matching on-chain behavior), the docs would be correct and `0` would work.
+
+3. **World's simulation uses a consistent `block.timestamp`.** If both `approve()` and `transferFrom()` within the same UserOp see the same `block.timestamp` in simulation (as they would on-chain), any of the near-current values would pass.


### PR DESCRIPTION
## TL;DR for World Devs

We cannot deposit into our vault via MiniKit `sendTransaction`. Every Permit2 `expiration` value we've tried is rejected — either by simulation (`simulation_failed`) or by validation (`permit_deadline_too_long`). **We've tried 7 different values across 7 PRs over 12+ hours.** The docs say to use `0` but that also fails.

We need to know: **what is the exact acceptable range for the `expiration` parameter in `Permit2.approve()` when called via MiniKit `sendTransaction`?**

---

## About Our App

**Harvest** — the first yield aggregator on World Chain. DeFi, for humans.

- **What it does**: Auto-compounds Morpho vault rewards for all depositors using a shared ERC-4626-style vault (Beefy Finance fork). An AI agent (AgentKit) acts as strategist — claiming Merkl rewards, swapping via Uniswap V3, redepositing into Morpho.
- **Built for**: ETHGlobal Cannes 2026 hackathon
- **Hosting**: Vercel (Next.js 16 App Router)
- **App Store status**: NOT approved — testing via Developer Preview QR code
- **UI**: Single-screen retro terminal (green-on-black). Commands: `deposit`, `withdraw`, `portfolio`, `vaults`, `agent status`
- **Repo**: https://github.com/ElliotFriedman/harvest-world (public)

---

## Our Stack

| Component | Details |
|-----------|---------|
| **Framework** | Next.js 16.2.2 (App Router, `"use client"`) |
| **Hosting** | Vercel |
| **MiniKit** | `@worldcoin/minikit-js` v2.0.2 |
| **IDKit** | `@worldcoin/idkit` v4.0.11 |
| **IDKit Server** | `@worldcoin/idkit-server` v1.1.0 |
| **Chain** | World Chain mainnet (chain ID 480) |
| **Encoding** | `viem` v2.47.6 `encodeFunctionData` |
| **Vault contract** | Custom ERC-4626 (Beefy fork) at `0x512CE44e4F69A98bC42A57ceD8257e65e63cD74f` |
| **Permit2** | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
| **USDC (Bridged)** | `0x79A02482A880bCE3F13e09Da970dC34db4CD24d1` |
| **Morpho Re7 USDC Vault** | `0xb1E80387EbE53Ff75a89736097D34dC8D9E9045B` |

### Developer Portal Config
- **Permit2 Tokens**: `0x79A02482A880bCE3F13e09Da970dC34db4CD24d1` (USDC)
- **Contract Entrypoints**: `0x512CE44e4F69A98bC42A57ceD8257e65e63cD74f` (vault), `0x000000000022D473030F116dDEE9F6B43aC78BA3` (Permit2)
- **App Store**: Not submitted / not approved — using Developer Preview QR code for testing

---

## The Deposit Flow

Our `sendTransaction` bundles two calls atomically:

```ts
// Transaction 1: Permit2 approve
Permit2.approve(USDC_ADDRESS, VAULT_ADDRESS, amount, expiration)

// Transaction 2: Vault deposit (calls Permit2.transferFrom internally)  
Vault.deposit(amount)
```

The vault's `deposit()` function (Solidity):
```solidity
function deposit(uint256 _amount) public nonReentrant {
    // ...
    PERMIT2.transferFrom(msg.sender, address(this), uint160(_amount), address(want()));
    // ...
}
```

Full frontend code: [`app/src/app/page.tsx` line ~375](https://github.com/ElliotFriedman/harvest-world/blob/main/app/src/app/page.tsx)

---

## What We've Tried — 7 Attempts, All Failed

| # | Expiration Value | Error | PR |
|---|-----------------|-------|----|
| 1 | `0` | `simulation_failed` | #34 |
| 2 | `now + 86400` (24h) | `permit_deadline_too_long` | #54 |
| 3 | `0` (retry) | `simulation_failed` | #56 |
| 4 | `now + 60` (1 min) | `permit_deadline_too_long` | #59 |
| 5 | `now + 15` (15s) | `permit_deadline_too_long` | #60 |
| 6 | `now + 0` (current timestamp) | `simulation_failed` | #62 |
| 7 | `now + 2` (2s) | `permit_deadline_too_long` | #64 |

**Pattern**: `0` and `now+0` → simulation_failed. Anything `>= now+2` → permit_deadline_too_long.

---

## Why This Is Contradictory

### On-chain Permit2 behavior (verified by reading source):

**`Allowance.sol`** — when `expiration = 0`, Permit2 stores `block.timestamp`:
```solidity
uint48 storedExpiration = expiration == 0 ? uint48(block.timestamp) : expiration;
```

**`AllowanceTransfer.sol`** — expiry check is strict `>`:
```solidity
if (block.timestamp > allowed.expiration) revert AllowanceExpired(allowed.expiration);
```

So on-chain, **every value we tried would work** because:
- `0` → stores `block.timestamp` → `block.timestamp > block.timestamp` is false → passes
- `now + N` → future timestamp → `block.timestamp > future` is false → passes

The rejection is entirely from World's simulation/validation layer, not from Permit2.

### The constraint space:
```
expiration = 0         → World rejects (simulation_failed)
expiration = now       → World rejects (simulation_failed)  
expiration = now + 2   → World rejects (permit_deadline_too_long)
expiration = now + 15  → World rejects (permit_deadline_too_long)
expiration = now + 60  → World rejects (permit_deadline_too_long)
```

There appears to be **no valid value** — or the acceptable range is undocumented.

---

## What Your Docs Say

> Expiration should always be set to 0 as the approval will be consumed in the same transaction.

```ts
args: [token, spender, amount, 0],
// Always set deadline to 0 as it will be consumed in the same transaction
```

We followed this. It fails with `simulation_failed`.

---

## All PRs in This Repo (for full context)

| PR | Title | State |
|----|-------|-------|
| #25 | docs: add and clean up docs directory | MERGED |
| #26 | feat: sybil resistance, Permit2 deposits, World ID + test infra | MERGED |
| #27 | Cleanup Local | MERGED |
| #28 | feat: test infrastructure with shared deployer library and CI | MERGED |
| #29 | feat: allow human-backed agents to deposit via AgentBook | MERGED |
| #30 | fix: access control hardening for withdraw and harvest | MERGED |
| #31 | fmt | MERGED |
| #32 | feat: deploy contracts to World Chain mainnet | MERGED |
| #33 | add deployed contract to spec | MERGED |
| #34 | feat: functional mini app with deposit, withdraw, portfolio | MERGED |
| #38 | fix: progressive disclosure + connect wallet button | MERGED |
| #39 | ci: add app install + build jobs | MERGED |
| #41 | fix: require wallet before deposit to prevent ProofInvalid | MERGED |
| #42 | fix: compact vaults display for mobile | MERGED |
| #43 | fix: add brand assets and metadata to Next.js app | MERGED |
| #44 | fix: signal staleness + single-tap get started flow | MERGED |
| #45 | feat: implement harvester agent API + terminal commands | MERGED |
| #46 | docs: add README | MERGED |
| #47 | fix: ABI-decode World ID proof (root cause of simulation_failed) | MERGED |
| #48 | debug: exhaustive logging to diagnose simulation_failed | MERGED |
| #49 | fix: downgrade IDKit to v2 for V3-compatible on-chain World ID proofs | MERGED |
| #50 | remove: on-chain human verification from vault | MERGED |
| #51 | fix: add Multicall3 address to fix portfolio 500 error | MERGED |
| #52 | feat: TransparentUpgradeableProxy + _disableInitializers | MERGED |
| #53 | fix: atomic proxy init in HarvestDeployer + rename Moo → Harvest | MERGED |
| **#54** | **fix: Permit2 allowance expiration causing deposit revert** | **MERGED** |
| #55 | fix: lazy-load IDKit to prevent white screen in World App | MERGED |
| **#56** | **fix: set Permit2 expiration to 0 per World docs** | **MERGED** |
| #57 | fix(app): rename vault shares label to hvUSDC, bump version to v1.5 | MERGED |
| #58 | docs: remove Supabase, update constraints, add brand assets | MERGED |
| **#59** | **fix: Permit2 expiration timestamp, bump v1.6** | **MERGED** |
| **#60** | **fix: reduce Permit2 expiration to 15s, bump v1.7** | **MERGED** |
| #61 | feat(app): button-first UX, deposit amount picker, v1.7 | OPEN |
| **#62** | **fix: Permit2 expiration to current timestamp, bump v1.8** | **MERGED** |
| #63 | fix(app): balance-aware deposit picker | OPEN |
| **#64** | **fix: Permit2 expiration now+2s, bump v1.9** | **MERGED** |

(Bolded PRs are the Permit2 expiration attempts)

---

## Questions for World Team

1. **What is the exact acceptable range for the `expiration` parameter?** The docs say `0` but that fails simulation.
2. **Is `permit_deadline_too_long` a simulation error or a pre-simulation validation?** If pre-simulation, what's the threshold?
3. **Does the simulation environment use a consistent `block.timestamp` across calls within a single UserOp?** If not, that explains why `0` (which stores `block.timestamp` at approve-time) fails at transferFrom-time.
4. **Is there a way to bypass the expiration validation** for the hackathon? We're at ETHGlobal Cannes and this is blocking our demo.

## Detailed failure log

See [`docs/permit2-expiration-failures.md`](https://github.com/ElliotFriedman/harvest-world/blob/docs/permit2-simulation-failure/docs/permit2-expiration-failures.md) in this PR for full source code analysis and hypotheses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)