### PR TITLE
debug: Permit2 expiration=0 for Tenderly trace, bump v2.0

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -78,7 +78,7 @@ function formatBigintUSDC(raw: bigint): string {
 
 export default function Terminal() {
   const [lines, setLines] = useState<string[]>([
-    "HARVEST v1.9 — Agentic DeFi, for humans.",
+    "HARVEST v2.0 — Agentic DeFi, for humans.",
     "World Chain yield aggregator.",
     "",
   ]);
@@ -372,12 +372,11 @@ export default function Terminal() {
     try {
       const amountRaw = BigInt(Math.floor(amount * 1e6));
 
-      // Permit2: 2s padding — strict > check means same-block passes
-      const expiration = Math.floor(Date.now() / 1000) + 2;
+      // Permit2: expiration 0 to trigger simulation failure for Tenderly debug
       const approveCalldata = encodeFunctionData({
         abi: PERMIT2_APPROVE_ABI,
         functionName: "approve",
-        args: [USDC_ADDRESS, VAULT_ADDRESS, amountRaw, expiration],
+        args: [USDC_ADDRESS, VAULT_ADDRESS, amountRaw, 0],
       });
 
       const depositCalldata = encodeFunctionData({


### PR DESCRIPTION
## Purpose

Intentionally set Permit2 expiration to `0` to trigger `simulation_failed`, then use World's debug API to get a Tenderly trace showing exactly what reverts.

## Steps after merge

1. Wait for Vercel deploy (~1-2 min)
2. Open World App — confirm you see **"HARVEST v2.0"** in the terminal header
3. Attempt a deposit → expect `simulation_failed`
4. Run the debug API:
```bash
curl -s "https://developer.world.org/api/v2/minikit/transaction/debug?app_id=app_4e0a09224d5cc08fca4cd09ef101f966" \
  -H "Authorization: Bearer api_a2V5Xzk5YTE4Yzc2M2I4NTZiNTQ3NjI5YWIwYWE1M2Q5MmU3OnNrXzdhYTMxOGI3Nzk0ODA2YzZjMmU2OWJjYjk5OTUyNTFmMWEzNTc3MGZjYzk2MWZhNQ" \
  | python3 -m json.tool
```
5. Get Tenderly URL → inspect revert trace

## Change
- `expiration` set to `0` (was `now + 2`)
- Version bumped to v2.0 (visual confirmation that deploy is live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)