### PR TITLE
fix(app): correct vault address + restore Permit2 expiration, v2.1

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,4 +1,4 @@
-# World App credentials (from Developer Portal)
+# ─── World App credentials (Developer Portal → Configuration) ────────────────
 NEXT_PUBLIC_APP_ID=app_...
 WORLD_RP_ID=rp_...
 
@@ -6,9 +6,18 @@ WORLD_RP_ID=rp_...
 # Generate via: npx @worldcoin/idkit-server keygen
 RP_SIGNING_KEY=0x...
 
-# Vault address — set after deploying contracts to World Chain mainnet (chainId 480)
-NEXT_PUBLIC_VAULT_ADDRESS=0x...
+# ─── Contracts (World Chain mainnet, chainId 480) ─────────────────────────────
+# Harvest vault proxy address — set after deploying with contracts/Deploy.s.sol
+# Current deployment: 0x512ce44e4f69a98bc42a57ced8257e65e63cd74f
+NEXT_PUBLIC_VAULT_ADDRESS=0x512ce44e4f69a98bc42a57ced8257e65e63cd74f
 
-# Agent wallet private key — used by harvester to call strategy.harvest()
-# Server-only, NEVER expose to browser
+# ─── RPC (server-only) ────────────────────────────────────────────────────────
+# Used by /api/balances to read on-chain state. Never exposed to the browser.
+# Get a key at https://alchemy.com or use the public fallback (rate-limited):
+#   https://worldchain.drpc.org
+RPC_URL=https://worldchain-mainnet.g.alchemy.com/v2/YOUR_KEY_HERE
+
+# ─── Agent / Harvester (server-only) ─────────────────────────────────────────
+# Private key of the agent wallet that calls strategy.harvest()
+# Fund it with ETH on World Chain for gas
 AGENT_PRIVATE_KEY=0x...

--- a/app/src/app/api/balances/route.ts
+++ b/app/src/app/api/balances/route.ts
@@ -16,7 +16,7 @@ const client = createPublicClient({
 });
 
 const USDC = "0x79A02482A880bCE3F13e09Da970dC34db4CD24d1" as const;
-const VAULT = "0xDA3cF80dC04F527563a40Ce17A5466d6A05eefBD" as const;
+const VAULT = (process.env.NEXT_PUBLIC_VAULT_ADDRESS ?? "0x512ce44e4f69a98bc42a57ced8257e65e63cd74f") as `0x${string}`;
 
 const balanceOfAbi = [{ inputs: [{ name: "account", type: "address" }], name: "balanceOf", outputs: [{ name: "", type: "uint256" }], stateMutability: "view", type: "function" }] as const;
 const vaultAbi = [

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -78,7 +78,7 @@ function formatBigintUSDC(raw: bigint): string {
 
 export default function Terminal() {
   const [lines, setLines] = useState<string[]>([
-    "HARVEST v2.0 — Agentic DeFi, for humans.",
+    "HARVEST v2.1 — Agentic DeFi, for humans.",
     "World Chain yield aggregator.",
     "",
   ]);
@@ -423,11 +423,11 @@ export default function Terminal() {
     try {
       const amountRaw = BigInt(Math.floor(amount * 1e6));
 
-      // Permit2: expiration 0 to trigger simulation failure for Tenderly debug
+      const expiration = Math.floor(Date.now() / 1000) + 60; // 1 minute from now
       const approveCalldata = encodeFunctionData({
         abi: PERMIT2_APPROVE_ABI,
         functionName: "approve",
-        args: [USDC_ADDRESS, VAULT_ADDRESS, amountRaw, 0],
+        args: [USDC_ADDRESS, VAULT_ADDRESS, amountRaw, expiration],
       });
 
       const depositCalldata = encodeFunctionData({

--- a/docs/infra-checklist.md
+++ b/docs/infra-checklist.md
@@ -164,21 +164,21 @@ The World Mini App FAQ explicitly states: **"Mini apps must be developed on main
 - [ ] **Configure Vercel environment variables**
   - Required variables (set in Vercel Dashboard > Project > Settings > Environment Variables):
     ```
-    NEXT_PUBLIC_APP_ID=app_xxxxxxxxxx          # From Developer Portal
-    NEXT_PUBLIC_WORLD_CHAIN_ID=480             # World Chain mainnet
-    NEXT_PUBLIC_ALCHEMY_RPC=https://worldchain-mainnet.g.alchemy.com/v2/YOUR_KEY
-    
-    # World Developer Portal
-    DEV_PORTAL_API_KEY=your_api_key            # For notification sending & verification
-    
-    # Contract addresses (add after deployment)
-    NEXT_PUBLIC_VAULT_CONTRACT=0x...
-    NEXT_PUBLIC_STRATEGY_CONTRACT=0x...
-    
-    # Optional
-    OPENAI_API_KEY=sk-...
-    ALCHEMY_API_KEY=your_key
+    # World App (Developer Portal → Configuration)
+    NEXT_PUBLIC_APP_ID=app_...           # Mini App ID
+    WORLD_RP_ID=rp_...                   # RP ID for IDKit
+    RP_SIGNING_KEY=0x...                 # Server-only signing key (never expose to browser)
+
+    # Contracts — World Chain mainnet (chainId 480)
+    NEXT_PUBLIC_VAULT_ADDRESS=0x512ce44e4f69a98bc42a57ced8257e65e63cd74f  # Harvest vault proxy
+
+    # RPC — server-only (used by /api/balances)
+    RPC_URL=https://worldchain-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
+
+    # Agent wallet — server-only (used by /api/agent/harvest)
+    AGENT_PRIVATE_KEY=0x...
     ```
+  - See `app/.env.example` for the full reference with comments.
   - Time: 15 minutes
   - Blocking: Functional deployment
   - Who: Frontend dev


### PR DESCRIPTION
## What was broken

**Problem 1: Wrong vault address**  
`/api/balances/route.ts` had `0xDA3cF80dC04F527563a40Ce17A5466d6A05eefBD` hardcoded — an empty vault. The real deployed vault is `0x512ce44e4f69a98bc42a57ced8257e65e63cd74f` (symbol: `harvestWorldMorphoUSDC`, verified on World Scan). Deposits went to the right vault but portfolio read from the wrong one → always showed $0.

**Problem 2: Permit2 expiration set to 0**  
The Tenderly debug session left `expiration = 0` in the Permit2 approve call. This causes all deposit transactions to fail at simulation (expired approval), so new deposits weren't going through.

## Fixes

- `api/balances/route.ts` — `VAULT` now reads from `NEXT_PUBLIC_VAULT_ADDRESS` env var (falls back to the correct deployed address)
- `page.tsx` — Permit2 expiration restored to `Date.now()/1000 + 60`
- `app/.env.example` — full env var reference with comments for Vercel deployment
- `docs/infra-checklist.md` — updated Vercel env vars section with correct var names and current vault address
- Version bump v2.0 → v2.1

## Test plan

- [ ] `portfolio` command shows user's hvUSDC shares and USD value (not $0.00)
- [ ] `deposit $10` flow completes — Permit2 approve doesn't expire before tx lands
- [ ] `/api/balances?wallet=0x...` returns non-zero vaultShares for deposited wallet
- [ ] Vercel env vars section in infra-checklist matches `app/.env.example`

🤖 Generated with [Claude Code](https://claude.com/claude-code)