### PR TITLE
fix(app): wire agent status to real Merkl API, fix strategy/vault addresses

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -11,6 +11,10 @@ RP_SIGNING_KEY=0x...
 # Current deployment: 0x512ce44e4f69a98bc42a57ced8257e65e63cd74f
 NEXT_PUBLIC_VAULT_ADDRESS=0x512ce44e4f69a98bc42a57ced8257e65e63cd74f
 
+# Harvest strategy proxy address (StrategyMorphoMerkl)
+# Current deployment: 0x313bA1D5D5AA1382a80BA839066A61d33C110489
+NEXT_PUBLIC_STRATEGY_ADDRESS=0x313bA1D5D5AA1382a80BA839066A61d33C110489
+
 # ─── RPC (server-only) ────────────────────────────────────────────────────────
 # Used by /api/balances to read on-chain state. Never exposed to the browser.
 # Get a key at https://alchemy.com or use the public fallback (rate-limited):

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -311,19 +311,63 @@ export default function Terminal() {
   }
 
   async function handleAgentStatus() {
-    print(
-      "HARVESTER AGENT",
-      "  Status:         ● ACTIVE",
-      "  Last harvest:   never",
-      "  Next check:     in ~6h",
-      "  Pending yield:  0 WLD",
-      ""
-    );
+    print("Loading agent status...");
+    try {
+      const s = await getAgentStatus();
+
+      const lastHarvestStr = s.lastHarvest
+        ? `${new Date(s.lastHarvest.timestamp).toLocaleString()} (+$${s.lastHarvest.wantEarned})`
+        : "never";
+
+      const nextCheckStr = (() => {
+        const ms = new Date(s.nextCheck).getTime() - Date.now();
+        if (ms <= 0) return "soon";
+        const h = Math.floor(ms / 3600_000);
+        const m = Math.floor((ms % 3600_000) / 60_000);
+        return h > 0 ? `in ~${h}h` : `in ~${m}m`;
+      })();
+
+      const poolUSD = s.balanceOfPool
+        ? `$${(Number(s.balanceOfPool) / 1e6).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+        : "--";
+
+      const rewardStr = s.pendingRewards
+        ? `${s.pendingRewards.amount} ($${s.pendingRewards.usdValue.toFixed(2)})`
+        : "0 WLD";
+
+      print(
+        "HARVESTER AGENT",
+        `  Status:         ● ${s.status.toUpperCase()}`,
+        `  Pool balance:   ${poolUSD}`,
+        `  Pending yield:  ${rewardStr}`,
+        `  Last harvest:   ${lastHarvestStr}`,
+        `  Next check:     ${nextCheckStr}`,
+        ""
+      );
+    } catch {
+      print("Error loading agent status. Try again.", "");
+    }
   }
 
   async function handleAgentHarvest() {
-    print("Triggering manual harvest...");
-    print("No pending rewards above threshold.", "");
+    print("Triggering harvest...");
+    try {
+      const result = await triggerHarvest();
+      if (result.success) {
+        print(
+          "Harvest complete.",
+          result.wantEarned ? `  Yield earned:  +$${result.wantEarned}` : "",
+          result.rewardsClaimed ? `  Rewards:       ${result.rewardsClaimed}` : "",
+          result.txHash ? `  Tx: ${result.txHash.slice(0, 10)}...` : "",
+          ""
+        );
+      } else {
+        const reason = result.message ?? result.reason ?? "unknown";
+        print(`Harvest skipped: ${reason}`, "");
+      }
+    } catch {
+      print("Error triggering harvest. Try again.", "");
+    }
   }
 
   // ── Easter egg ──────────────────────────────────────────────────────────────

--- a/app/src/lib/harvester.ts
+++ b/app/src/lib/harvester.ts
@@ -3,8 +3,12 @@
 // Used by /api/agent/status and /api/agent/harvest routes.
 // ---------------------------------------------------------------------------
 
-export const STRATEGY_ADDRESS = "0xd2753e1Ce625A776A4d73f0251419Ba5Dfc1c0A5" as const;
-export const VAULT_ADDRESS = "0xDA3cF80dC04F527563a40Ce17A5466d6A05eefBD" as const;
+export const STRATEGY_ADDRESS = (
+  process.env.NEXT_PUBLIC_STRATEGY_ADDRESS ?? "0x313bA1D5D5AA1382a80BA839066A61d33C110489"
+) as `0x${string}`;
+export const VAULT_ADDRESS = (
+  process.env.NEXT_PUBLIC_VAULT_ADDRESS ?? "0x512ce44e4f69a98bc42a57ced8257e65e63cd74f"
+) as `0x${string}`;
 export const WLD_ADDRESS = "0x2cFc85d8E48F8EAB294be644d9E25C3030863003" as const;
 
 // ─── ABIs ─────────────────────────────────────────────────────────────────────

--- a/docs/infra-checklist.md
+++ b/docs/infra-checklist.md
@@ -170,7 +170,8 @@ The World Mini App FAQ explicitly states: **"Mini apps must be developed on main
     RP_SIGNING_KEY=0x...                 # Server-only signing key (never expose to browser)
 
     # Contracts — World Chain mainnet (chainId 480)
-    NEXT_PUBLIC_VAULT_ADDRESS=0x512ce44e4f69a98bc42a57ced8257e65e63cd74f  # Harvest vault proxy
+    NEXT_PUBLIC_VAULT_ADDRESS=0x512ce44e4f69a98bc42a57ced8257e65e63cd74f      # Harvest vault proxy
+    NEXT_PUBLIC_STRATEGY_ADDRESS=0x313bA1D5D5AA1382a80BA839066A61d33C110489  # Harvest strategy proxy
 
     # RPC — server-only (used by /api/balances)
     RPC_URL=https://worldchain-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY


### PR DESCRIPTION
## What was broken

**Wrong addresses in `harvester.ts`:**
- `STRATEGY_ADDRESS` was `0xd2753...` — a wrong address. Merkl API was queried for the wrong account, always returning 0 rewards.
- `VAULT_ADDRESS` was `0xDA3...` — same wrong vault from the previous bug.

Correct addresses confirmed on World Scan:
- Strategy proxy: `0x313bA1D5D5AA1382a80BA839066A61d33C110489` (impl: StrategyMorphoMerkl)
- Vault proxy: `0x512ce44e4f69a98bc42a57ced8257e65e63cd74f` (impl: BeefyVaultV7, symbol: harvestWorldMorphoUSDC)

**Hardcoded `handleAgentStatus` / `handleAgentHarvest`:**
- Both handlers printed static strings and never called the API.
- Pending yield always showed "0 WLD" regardless of actual Merkl rewards.

## Fixes

- `harvester.ts` — both addresses read from `NEXT_PUBLIC_STRATEGY_ADDRESS` / `NEXT_PUBLIC_VAULT_ADDRESS` with correct deployed fallbacks
- `handleAgentStatus` — calls `/api/agent/status`, displays real pool balance, pending WLD rewards (from Merkl), last harvest time, next check countdown
- `handleAgentHarvest` — calls `/api/agent/harvest`, surfaces yield earned + tx hash on success

## Test plan

- [ ] `agent status` in terminal shows real pool balance (not "--")
- [ ] Pending rewards shows actual WLD from Merkl (or "0 WLD" if none accrued yet)
- [ ] Last harvest shows timestamp of most recent harvest (or "never")
- [ ] `agent harvest` triggers the route and shows success/skip reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)