### PR TITLE
fix(app): set Permit2 expiration to 0 per World docs

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -326,23 +326,6 @@ export default function Terminal() {
     print("No pending rewards above threshold.", "");
   }
 
-  // ── Easter egg ──────────────────────────────────────────────────────────────
-
-  async function handleEasterEgg() {
-    await typewriterPrint("* you found the easter egg. congrats. *");
-    await new Promise<void>((r) => setTimeout(r, 500));
-    print("");
-    await typewriterPrint("we wanted to add the wonder back into finance.");
-    await new Promise<void>((r) => setTimeout(r, 200));
-    await typewriterPrint("the feeling of getting a new computer.");
-    await new Promise<void>((r) => setTimeout(r, 200));
-    await typewriterPrint("and entering a whole new world...");
-    await new Promise<void>((r) => setTimeout(r, 600));
-    print("");
-    await typewriterPrint("we hope you enjoy :)");
-    print("");
-  }
-
   // ── Deposit picker flow ──────────────────────────────────────────────────────
 
   async function openDepositPicker() {
@@ -452,11 +435,12 @@ export default function Terminal() {
     try {
       const amountRaw = BigInt(Math.floor(amount * 1e6));
 
-      const expiration = Math.floor(Date.now() / 1000) + 60; // 1 minute from now
+      // set to zero per world docs.
+      const expiration = 0;
       const approveCalldata = encodeFunctionData({
         abi: PERMIT2_APPROVE_ABI,
         functionName: "approve",
-        args: [USDC_ADDRESS, VAULT_ADDRESS, amountRaw, expiration],
+        args: [USDC_ADDRESS, VAULT_ADDRESS, amountRaw, 0],
       });
 
       const depositCalldata = encodeFunctionData({
@@ -593,8 +577,6 @@ export default function Terminal() {
       await handleAgentHarvest();
     } else if (cmd === "clear") {
       setLines([]);
-    } else if (trimmed === "easter egg") {
-      await handleEasterEgg();
     } else {
       print(`Unknown command: '${cmd}'. Type 'help' for options.`, "");
     }

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -326,6 +326,23 @@ export default function Terminal() {
     print("No pending rewards above threshold.", "");
   }
 
+  // ── Easter egg ──────────────────────────────────────────────────────────────
+
+  async function handleEasterEgg() {
+    await typewriterPrint("* you found the easter egg. congrats. *");
+    await new Promise<void>((r) => setTimeout(r, 500));
+    print("");
+    await typewriterPrint("we wanted to add the wonder back into finance.");
+    await new Promise<void>((r) => setTimeout(r, 200));
+    await typewriterPrint("the feeling of getting a new computer.");
+    await new Promise<void>((r) => setTimeout(r, 200));
+    await typewriterPrint("and entering a whole new world...");
+    await new Promise<void>((r) => setTimeout(r, 600));
+    print("");
+    await typewriterPrint("we hope you enjoy :)");
+    print("");
+  }
+
   // ── Deposit picker flow ──────────────────────────────────────────────────────
 
   async function openDepositPicker() {
@@ -440,7 +457,7 @@ export default function Terminal() {
       const approveCalldata = encodeFunctionData({
         abi: PERMIT2_APPROVE_ABI,
         functionName: "approve",
-        args: [USDC_ADDRESS, VAULT_ADDRESS, amountRaw, 0],
+        args: [USDC_ADDRESS, VAULT_ADDRESS, amountRaw, expiration],
       });
 
       const depositCalldata = encodeFunctionData({
@@ -577,6 +594,8 @@ export default function Terminal() {
       await handleAgentHarvest();
     } else if (cmd === "clear") {
       setLines([]);
+    } else if (trimmed === "easter egg") {
+      await handleEasterEgg();
     } else {
       print(`Unknown command: '${cmd}'. Type 'help' for options.`, "");
     }

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -78,7 +78,7 @@ function formatBigintUSDC(raw: bigint): string {
 
 export default function Terminal() {
   const [lines, setLines] = useState<string[]>([
-    "HARVEST v2.1 — Agentic DeFi, for humans.",
+    "HARVEST v2.2 — Agentic DeFi, for humans.",
     "World Chain yield aggregator.",
     "",
   ]);


### PR DESCRIPTION
## Problem

Deposits were failing with **"permit deadline too long"** from the World App transaction simulator. This was caused by setting the Permit2 `expiration` to `Date.now()/1000 + 60` (1 minute in the future).

## Fix

Set `expiration = 0` per World's Permit2 integration docs. When expiration is `0`, Permit2 treats it as a single-transaction atomic approval — the allowance is only valid within the same transaction bundle, which is exactly the pattern we need for the atomic `approve → deposit` multicall.

## Test plan

- [ ] Tap deposit → select amount → transaction goes through without "permit deadline too long" error
- [ ] Deposit lands on-chain and shares appear in portfolio

🤖 Generated with [Claude Code](https://claude.com/claude-code)