### PR TITLE
feat(portfolio): show total USD value as wallet USDC + vault shares

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harvest-app",
-  "version": "1.6.0",
+  "version": "1.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harvest-app",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -296,13 +296,15 @@ export default function Terminal() {
 
       if (vaultShares > BigInt(0)) setHasShares(true);
 
-      const usdValue = (vaultShares * pricePerShare) / BigInt(1e18);
+      const vaultUsdValue = (vaultShares * pricePerShare) / BigInt(1e18);
+      const totalUsdValue = usdcBalance + vaultUsdValue;
 
       print(
         `Portfolio for ${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}`,
         `  USDC in wallet: $${formatBigintUSDC(usdcBalance)}`,
         `  Vault shares:   ${formatBigintUSDC(vaultShares)} hvUSDC`,
-        `  USD value:      $${formatBigintUSDC(usdValue)}`,
+        `  Vault USD value: $${formatBigintUSDC(vaultUsdValue)}`,
+        `  Total USD value: $${formatBigintUSDC(totalUsdValue)}`,
         ""
       );
     } catch {

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -78,7 +78,7 @@ function formatBigintUSDC(raw: bigint): string {
 
 export default function Terminal() {
   const [lines, setLines] = useState<string[]>([
-    "HARVEST v2.3 — Agentic DeFi, for humans.",
+    "HARVEST v2.4 — Agentic DeFi, for humans.",
     "World Chain yield aggregator.",
     "",
   ]);


### PR DESCRIPTION
## Summary
- Portfolio now displays both vault USD value and total USD value (wallet USDC + vault shares)
- Renamed `usdValue` → `vaultUsdValue` for clarity; added `totalUsdValue = usdcBalance + vaultUsdValue`
- Bumped version 1.5.0 → 1.6.0

## Test plan
- [ ] Run `portfolio` command — verify four lines appear: USDC in wallet, Vault shares, Vault USD value, Total USD value
- [ ] Deposit some USDC, run `portfolio` — total should equal wallet balance + vault position

🤖 Generated with [Claude Code](https://claude.com/claude-code)