### PR TITLE
feat: AgentKit harvester + burner wallet setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 app/.env.local
 
 signing-key.json
+.harvester-wallet.json
 app/node_modules/

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -1,0 +1,6 @@
+# Agent private key — the EOA that signs harvest transactions on World Chain.
+# Must be the `manager` or `keeper` of the strategy contract.
+AGENT_PRIVATE_KEY=0x...
+
+# World Chain RPC URL (optional — defaults to https://worldchain.drpc.org)
+RPC_URL=https://worldchain.drpc.org

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,0 +1,94 @@
+# Harvest Agent
+
+Standalone harvester agent for the Harvest yield aggregator on World Chain (chainId 480). Claims Merkl rewards, swaps to USDC via Uniswap V3, and redeposits into the Morpho vault — auto-compounding yield for all depositors.
+
+Uses **World AgentKit** to prove the agent is backed by a verified human (World ID / Orb).
+
+## Architecture
+
+```
+Agent wallet (burner EOA)
+  ├── Registered in AgentBook (human-backed via World ID)
+  ├── Owns the Strategy contract (can call harvest/claim)
+  └── Funded with small ETH for gas (~0.002 ETH)
+
+Harvest cycle:
+  1. Fetch unclaimed Merkl rewards for the strategy
+  2. Call strategy.claim() — claim rewards from Merkl distributor
+  3. Call strategy.harvest() — swap WLD → WETH → USDC, redeposit into Morpho
+  4. Log share price increase
+```
+
+## Setup
+
+### 1. Generate and fund a burner wallet
+
+```bash
+./contracts/script/setup-harvester.sh
+```
+
+This script:
+- Generates a fresh EOA
+- Saves the key to `.harvester-wallet.json` (gitignored)
+- Funds it with ETH from the deployer keystore
+- Transfers strategy ownership to the burner
+
+### 2. Register with AgentKit
+
+```bash
+npx @worldcoin/agentkit-cli register <BURNER_ADDRESS>
+```
+
+Requires scanning a QR code with World App (Orb-verified). This registers the agent wallet in AgentBook on World Chain, proving it's human-backed.
+
+### 3. Set environment variables
+
+```bash
+# In Vercel (for the cron endpoint):
+AGENT_PRIVATE_KEY=0x...   # burner wallet private key
+CRON_SECRET=<random-hex>  # protects the GET endpoint
+
+# For running locally:
+export AGENT_PRIVATE_KEY=0x...
+export RPC_URL=https://worldchain.drpc.org  # optional
+```
+
+## Running
+
+**Locally (one-shot):**
+```bash
+cd agent
+npm install
+AGENT_PRIVATE_KEY=0x... npm start
+```
+
+**Via Vercel Cron (automated):**
+
+The app's `vercel.json` configures a daily cron that hits `GET /api/agent/harvest`. The endpoint verifies the `CRON_SECRET` bearer token and runs the same harvest logic.
+
+## Contract Addresses
+
+| Contract | Address |
+|----------|---------|
+| Strategy | `0x313bA1D5D5AA1382a80BA839066A61d33C110489` |
+| Vault | `0x512CE44e4F69A98bC42A57ceD8257e65e63cD74f` |
+| Agent (burner) | `0x39e1e01f4CB9B2FED78892aa378aB2baf0F759b9` |
+| AgentBook Tx | `0x7af7c3c210fecd172bd20e85a4ac4cc96ef83a85f24a62066b86af7fd9974352` |
+
+## Roadmap
+
+**Permissionless harvesting via on-chain AgentKit gating.** Currently, only the strategy owner (burner wallet) can call `harvest()`. The next step is to gate `harvest()` on-chain so that *any* wallet registered as human-backed in AgentBook can compound on behalf of the entire pool. This makes the protocol fully permissionless — any verified human (or their agent) can trigger a harvest, removing the single-operator dependency and further decentralizing the system. See [#75](https://github.com/ElliotFriedman/harvest-world/issues/75) for tracking.
+
+**Harvester role separation.** Split the current owner-level access into a dedicated `harvester` role that can only call `harvest()` and `claim()`, not admin functions like `pause()` or `transferOwnership()`.
+
+## File Structure
+
+```
+agent/
+  src/
+    index.ts       — Entry point: env validation, AgentKit check, harvest
+    agentkit.ts    — AgentBook verification (human-backed proof)
+    harvester.ts   — Core harvest logic (claim + harvest via viem)
+    merkl.ts       — Merkl rewards + WLD price fetchers
+    config.ts      — Addresses, ABIs, chain config
+```

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@harvest/agent",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Harvest yield aggregator agent — claims Merkl rewards and auto-compounds via Morpho on World Chain",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "harvest": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@worldcoin/agentkit": "^0.1.6",
+    "viem": "^2.30.2",
+    "tsx": "^4.19.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/agent/src/agentkit.ts
+++ b/agent/src/agentkit.ts
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------------
+// Harvest Agent — AgentKit integration for human-backed agent identity
+// ---------------------------------------------------------------------------
+//
+// The agent wallet is registered on-chain in World's AgentBook contract via:
+//   npx @worldcoin/agentkit-cli register <agent-wallet-address>
+//
+// This module verifies that registration on startup. The agent still signs
+// transactions with its private key — AgentKit provides the identity/attestation
+// layer proving the agent is human-backed (World ID verified).
+// ---------------------------------------------------------------------------
+
+import { createAgentBookVerifier } from "@worldcoin/agentkit";
+import { WORLD_CHAIN_CAIP2, RPC_URL } from "./config.js";
+
+/**
+ * Verify that the agent wallet is registered as human-backed in AgentBook.
+ *
+ * AgentBook is a World Chain contract that maps wallet addresses to anonymous
+ * human identifiers. When an agent is registered via the AgentKit CLI, the
+ * deployer scans a QR code with World App (Orb-verified), which records the
+ * agent address -> human ID mapping on-chain.
+ *
+ * @returns The human ID (hex string) if registered, or null if not.
+ */
+export async function verifyAgentHumanBacking(
+  agentAddress: string
+): Promise<string | null> {
+  console.log("[AgentKit] Checking human-backing for agent wallet...");
+  console.log(`  Agent address: ${agentAddress}`);
+  console.log(`  AgentBook chain: ${WORLD_CHAIN_CAIP2}`);
+
+  try {
+    const agentBook = createAgentBookVerifier({ rpcUrl: RPC_URL });
+    const humanId = await agentBook.lookupHuman(agentAddress, WORLD_CHAIN_CAIP2);
+
+    if (humanId) {
+      console.log(`[AgentKit] Agent registered as human-backed via AgentKit`);
+      console.log(`  Human ID: ${humanId}`);
+      return humanId;
+    } else {
+      console.warn(
+        `[AgentKit] Agent wallet is NOT registered in AgentBook.`
+      );
+      console.warn(
+        `  To register, run: npx @worldcoin/agentkit-cli register ${agentAddress}`
+      );
+      return null;
+    }
+  } catch (error) {
+    console.error(
+      "[AgentKit] Failed to verify agent human-backing:",
+      error instanceof Error ? error.message : error
+    );
+    console.warn(
+      "[AgentKit] Continuing without AgentKit verification (graceful degradation)."
+    );
+    return null;
+  }
+}

--- a/agent/src/config.ts
+++ b/agent/src/config.ts
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------------------
+// Harvest Agent — configuration, constants, and ABIs
+// ---------------------------------------------------------------------------
+
+import type { Chain } from "viem";
+
+// ─── Contract addresses (World Chain mainnet, chainId 480) ──────────────────
+
+export const STRATEGY_ADDRESS =
+  "0x313bA1D5D5AA1382a80BA839066A61d33C110489" as const;
+export const VAULT_ADDRESS =
+  "0x512CE44e4F69A98bC42A57ceD8257e65e63cD74f" as const;
+export const WLD_ADDRESS =
+  "0x2cFc85d8E48F8EAB294be644d9E25C3030863003" as const;
+export const USDC_ADDRESS =
+  "0x79A02482A880bCE3F13e09Da970dC34db4CD24d1" as const;
+
+// ─── Chain config ────────────────────────────────────────────────────────────
+
+export const RPC_URL =
+  process.env.RPC_URL || "https://worldchain.drpc.org";
+
+export const worldChain: Chain = {
+  id: 480,
+  name: "World Chain",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  rpcUrls: {
+    default: { http: [RPC_URL] },
+  },
+};
+
+// ─── CAIP-2 chain identifier (used by AgentKit) ─────────────────────────────
+
+export const WORLD_CHAIN_CAIP2 = "eip155:480";
+
+// ─── ABIs ────────────────────────────────────────────────────────────────────
+
+export const strategyAbi = [
+  {
+    name: "claim",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "_tokens", type: "address[]" },
+      { name: "_amounts", type: "uint256[]" },
+      { name: "_proofs", type: "bytes32[][]" },
+    ],
+    outputs: [],
+  },
+  {
+    name: "harvest",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "callFeeRecipient", type: "address" }],
+    outputs: [],
+  },
+  {
+    name: "balanceOfPool",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;
+
+export const vaultAbi = [
+  {
+    name: "getPricePerFullShare",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    name: "balance",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;

--- a/agent/src/harvester.ts
+++ b/agent/src/harvester.ts
@@ -1,0 +1,173 @@
+// ---------------------------------------------------------------------------
+// Harvest Agent — core harvest logic (claim Merkl rewards + harvest)
+// ---------------------------------------------------------------------------
+
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  formatUnits,
+  type Hex,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import {
+  STRATEGY_ADDRESS,
+  VAULT_ADDRESS,
+  worldChain,
+  RPC_URL,
+  strategyAbi,
+  vaultAbi,
+} from "./config.js";
+import { fetchMerklRewards, formatTokenAmount } from "./merkl.js";
+
+// ─── Result type ─────────────────────────────────────────────────────────────
+
+export interface HarvestResult {
+  success: boolean;
+  reason?: string;
+  claimTxHash?: string;
+  harvestTxHash?: string;
+  rewardsClaimed?: string;
+  oldSharePrice?: string;
+  newSharePrice?: string;
+}
+
+// ─── Main harvest function ───────────────────────────────────────────────────
+
+export async function runHarvest(agentPrivateKey: Hex): Promise<HarvestResult> {
+  // Create clients
+  const publicClient = createPublicClient({
+    chain: worldChain,
+    transport: http(RPC_URL),
+  });
+
+  const account = privateKeyToAccount(agentPrivateKey);
+  const walletClient = createWalletClient({
+    account,
+    chain: worldChain,
+    transport: http(RPC_URL),
+  });
+
+  console.log(`\n[Harvest] Agent wallet: ${account.address}`);
+  console.log(`[Harvest] Strategy: ${STRATEGY_ADDRESS}`);
+  console.log(`[Harvest] Vault: ${VAULT_ADDRESS}`);
+
+  // ── Step 1: Fetch Merkl rewards ──────────────────────────────────────────
+
+  console.log("\n[Step 1/4] Fetching Merkl rewards for strategy...");
+  const rewards = await fetchMerklRewards(STRATEGY_ADDRESS);
+
+  if (rewards.length === 0) {
+    console.log("  No unclaimed Merkl rewards found. Nothing to harvest.");
+    return { success: false, reason: "no_rewards" };
+  }
+
+  console.log(`  Found ${rewards.length} reward token(s) with unclaimed balances:`);
+  for (const r of rewards) {
+    console.log(`    - ${formatTokenAmount(r.unclaimed)} ${r.symbol} (${r.token})`);
+  }
+
+  // ── Step 2: Read share price before harvest ──────────────────────────────
+
+  console.log("\n[Step 2/4] Reading vault share price (before)...");
+  const priceBefore = await publicClient
+    .readContract({
+      address: VAULT_ADDRESS,
+      abi: vaultAbi,
+      functionName: "getPricePerFullShare",
+    })
+    .catch(() => 0n);
+
+  console.log(`  Price per full share: ${formatUnits(priceBefore, 6)} USDC`);
+
+  // ── Step 3: Claim rewards from Merkl ─────────────────────────────────────
+
+  console.log("\n[Step 3/4] Claiming rewards from Merkl distributor...");
+  const tokens = rewards.map((r) => r.token as `0x${string}`);
+  const amounts = rewards.map((r) => r.amount);
+  const proofs = rewards.map((r) => r.proofs as `0x${string}`[]);
+
+  const rewardsSummary = rewards
+    .map((r) => `${formatTokenAmount(r.unclaimed)} ${r.symbol}`)
+    .join(", ");
+
+  const claimHash = await walletClient.writeContract({
+    address: STRATEGY_ADDRESS,
+    abi: strategyAbi,
+    functionName: "claim",
+    args: [tokens, amounts, proofs],
+  });
+
+  console.log(`  Claim tx submitted: ${claimHash}`);
+  console.log("  Waiting for confirmation...");
+  const claimReceipt = await publicClient.waitForTransactionReceipt({
+    hash: claimHash,
+  });
+  console.log(
+    `  Claim confirmed in block ${claimReceipt.blockNumber} (status: ${claimReceipt.status})`
+  );
+
+  if (claimReceipt.status === "reverted") {
+    console.error("  Claim transaction reverted!");
+    return { success: false, reason: "claim_reverted", claimTxHash: claimHash };
+  }
+
+  // ── Step 4: Harvest — swap rewards to USDC and redeposit into Morpho ────
+
+  console.log("\n[Step 4/4] Harvesting (swap + redeposit)...");
+  const harvestHash = await walletClient.writeContract({
+    address: STRATEGY_ADDRESS,
+    abi: strategyAbi,
+    functionName: "harvest",
+    args: [account.address], // callFeeRecipient = agent wallet
+  });
+
+  console.log(`  Harvest tx submitted: ${harvestHash}`);
+  console.log("  Waiting for confirmation...");
+  const harvestReceipt = await publicClient.waitForTransactionReceipt({
+    hash: harvestHash,
+  });
+  console.log(
+    `  Harvest confirmed in block ${harvestReceipt.blockNumber} (status: ${harvestReceipt.status})`
+  );
+
+  if (harvestReceipt.status === "reverted") {
+    console.error("  Harvest transaction reverted!");
+    return {
+      success: false,
+      reason: "harvest_reverted",
+      claimTxHash: claimHash,
+      harvestTxHash: harvestHash,
+      rewardsClaimed: rewardsSummary,
+    };
+  }
+
+  // ── Read share price after harvest ───────────────────────────────────────
+
+  const priceAfter = await publicClient
+    .readContract({
+      address: VAULT_ADDRESS,
+      abi: vaultAbi,
+      functionName: "getPricePerFullShare",
+    })
+    .catch(() => 0n);
+
+  console.log(`\n  Share price before: ${formatUnits(priceBefore, 6)} USDC`);
+  console.log(`  Share price after:  ${formatUnits(priceAfter, 6)} USDC`);
+
+  if (priceAfter > priceBefore) {
+    const increase = priceAfter - priceBefore;
+    console.log(
+      `  Share price increased by ${formatUnits(increase, 6)} USDC per share`
+    );
+  }
+
+  return {
+    success: true,
+    claimTxHash: claimHash,
+    harvestTxHash: harvestHash,
+    rewardsClaimed: rewardsSummary,
+    oldSharePrice: formatUnits(priceBefore, 6),
+    newSharePrice: formatUnits(priceAfter, 6),
+  };
+}

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1,0 +1,105 @@
+// ---------------------------------------------------------------------------
+// Harvest Agent — main entry point
+// ---------------------------------------------------------------------------
+//
+// Standalone harvester for the Harvest yield aggregator on World Chain.
+// Claims Merkl rewards, swaps to USDC, and redeposits into Morpho vaults.
+//
+// The agent uses World's AgentKit SDK for human-backed identity verification.
+// The agent wallet must be registered via:
+//   npx @worldcoin/agentkit-cli register <address>
+//
+// Usage:
+//   AGENT_PRIVATE_KEY=0x... npx tsx agent/src/index.ts
+//
+// Environment variables:
+//   AGENT_PRIVATE_KEY  — Required. Private key for the agent wallet.
+//   RPC_URL            — Optional. World Chain RPC (default: https://worldchain.drpc.org)
+// ---------------------------------------------------------------------------
+
+import type { Hex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { verifyAgentHumanBacking } from "./agentkit.js";
+import { runHarvest } from "./harvester.js";
+
+async function main() {
+  console.log("=".repeat(60));
+  console.log("  Harvest Agent — World Chain Yield Optimizer");
+  console.log("  DeFi, for humans.");
+  console.log("=".repeat(60));
+  console.log(`  Time: ${new Date().toISOString()}`);
+  console.log(`  Chain: World Chain (480)`);
+
+  // ── Validate environment ─────────────────────────────────────────────────
+
+  const agentKey = process.env.AGENT_PRIVATE_KEY;
+  if (!agentKey) {
+    console.error(
+      "\n[Error] AGENT_PRIVATE_KEY not set. Export it or add to .env file."
+    );
+    console.error("  Example: AGENT_PRIVATE_KEY=0xabc... npx tsx src/index.ts");
+    process.exit(1);
+  }
+
+  // Derive the agent wallet address from the private key
+  const account = privateKeyToAccount(agentKey as Hex);
+  console.log(`  Agent wallet: ${account.address}`);
+
+  // ── AgentKit: verify human-backed identity ───────────────────────────────
+
+  console.log("\n" + "-".repeat(60));
+  const humanId = await verifyAgentHumanBacking(account.address);
+
+  if (humanId) {
+    console.log("[AgentKit] Human-backed agent identity confirmed.");
+  } else {
+    console.warn(
+      "[AgentKit] Agent is NOT registered as human-backed. Proceeding anyway."
+    );
+    console.warn(
+      "  For AgentKit prize eligibility, register with: npx @worldcoin/agentkit-cli register"
+    );
+  }
+
+  // ── Run harvest cycle ────────────────────────────────────────────────────
+
+  console.log("\n" + "-".repeat(60));
+  console.log("[Harvest] Starting harvest cycle...\n");
+
+  const result = await runHarvest(agentKey as Hex);
+
+  // ── Report results ───────────────────────────────────────────────────────
+
+  console.log("\n" + "=".repeat(60));
+  if (result.success) {
+    console.log("  HARVEST SUCCESSFUL");
+    console.log(`  Rewards claimed: ${result.rewardsClaimed}`);
+    console.log(`  Claim tx:    ${result.claimTxHash}`);
+    console.log(`  Harvest tx:  ${result.harvestTxHash}`);
+    console.log(
+      `  Share price: ${result.oldSharePrice} -> ${result.newSharePrice} USDC`
+    );
+  } else if (result.reason === "no_rewards") {
+    console.log("  NO REWARDS TO HARVEST");
+    console.log(
+      "  The strategy has no unclaimed Merkl rewards. Will check again next cycle."
+    );
+  } else {
+    console.error(`  HARVEST FAILED: ${result.reason}`);
+    if (result.claimTxHash) {
+      console.error(`  Claim tx: ${result.claimTxHash}`);
+    }
+    if (result.harvestTxHash) {
+      console.error(`  Harvest tx: ${result.harvestTxHash}`);
+    }
+  }
+  console.log("=".repeat(60));
+
+  // Exit with appropriate code
+  process.exit(result.success || result.reason === "no_rewards" ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("\n[Fatal] Unhandled error:", err);
+  process.exit(1);
+});

--- a/agent/src/merkl.ts
+++ b/agent/src/merkl.ts
@@ -1,0 +1,116 @@
+// ---------------------------------------------------------------------------
+// Harvest Agent — Merkl rewards fetcher and WLD price fetcher
+// ---------------------------------------------------------------------------
+
+import { WLD_ADDRESS } from "./config.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface MerklReward {
+  token: string;
+  symbol: string;
+  amount: bigint;
+  claimed: bigint;
+  unclaimed: bigint;
+  proofs: string[];
+}
+
+// ─── Merkl rewards fetcher ───────────────────────────────────────────────────
+
+export async function fetchMerklRewards(
+  strategyAddress: string
+): Promise<MerklReward[]> {
+  const url = `https://api.merkl.xyz/v4/users/${strategyAddress}/rewards?chainId=480`;
+  console.log(`  Fetching Merkl rewards from ${url}`);
+
+  const res = await fetch(url);
+
+  if (!res.ok) {
+    console.error(`  Merkl API error: ${res.status} ${res.statusText}`);
+    return [];
+  }
+
+  const data = await res.json();
+  const rewards: MerklReward[] = [];
+
+  // Merkl v4 response shape varies — handle both flat array and chain-keyed object
+  let entries: any[] = [];
+  if (Array.isArray(data)) {
+    entries = data;
+  } else if (typeof data === "object" && data !== null) {
+    // Merkl v4: keyed by chain ID, e.g. { "480": { "campaignData": [...] } }
+    const chainData = (data as any)["480"] ?? Object.values(data)[0];
+    if (Array.isArray(chainData)) {
+      entries = chainData;
+    } else if (chainData?.campaignData) {
+      entries = chainData.campaignData;
+    } else if (chainData?.rewards) {
+      entries = Array.isArray(chainData.rewards)
+        ? chainData.rewards
+        : Object.values(chainData.rewards);
+    }
+  }
+
+  for (const entry of entries) {
+    if (!entry) continue;
+    const tokenAddr = entry?.token?.address ?? entry?.tokenAddress ?? "";
+    const symbol = entry?.token?.symbol ?? entry?.symbol ?? "???";
+    const totalAmount = BigInt(entry?.amount ?? "0");
+    const claimedAmount = BigInt(entry?.claimed ?? "0");
+    const unclaimed = totalAmount - claimedAmount;
+    const proofs: string[] = entry?.proofs ?? [];
+
+    if (unclaimed > 0n) {
+      rewards.push({
+        token: tokenAddr,
+        symbol,
+        amount: totalAmount,
+        claimed: claimedAmount,
+        unclaimed,
+        proofs,
+      });
+    }
+  }
+
+  return rewards;
+}
+
+// ─── WLD price fetcher ───────────────────────────────────────────────────────
+
+let cachedWldPrice: { price: number; fetchedAt: number } | null = null;
+const PRICE_CACHE_MS = 5 * 60_000; // 5 minutes
+
+export async function fetchWldPrice(): Promise<number> {
+  if (cachedWldPrice && Date.now() - cachedWldPrice.fetchedAt < PRICE_CACHE_MS) {
+    return cachedWldPrice.price;
+  }
+
+  try {
+    const url = `https://coins.llama.fi/prices/current/worldchain:${WLD_ADDRESS}`;
+    const res = await fetch(url);
+
+    if (!res.ok) {
+      console.error(`  DeFi Llama price error: ${res.status}`);
+      return cachedWldPrice?.price ?? 0.89;
+    }
+
+    const data = await res.json();
+    const key = `worldchain:${WLD_ADDRESS}`.toLowerCase();
+    const price = data?.coins?.[key]?.price ?? 0.89;
+
+    cachedWldPrice = { price, fetchedAt: Date.now() };
+    return price;
+  } catch {
+    return cachedWldPrice?.price ?? 0.89;
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+export function formatTokenAmount(raw: bigint, decimals = 18): string {
+  const divisor = 10n ** BigInt(decimals);
+  const whole = raw / divisor;
+  const frac = raw % divisor;
+  const fracStr = frac.toString().padStart(decimals, "0").slice(0, 4);
+  return `${whole}.${fracStr}`;
+}

--- a/agent/tsconfig.json
+++ b/agent/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/contracts/script/setup-harvester.sh
+++ b/contracts/script/setup-harvester.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ─── Harvest Agent Burner Wallet Setup ────────────────────────────────────────
+# Generates a burner wallet, funds it with ETH, and transfers strategy ownership.
+# Uses the solidity-labs-deployer keystore for signing.
+# ──────────────────────────────────────────────────────────────────────────────
+
+RPC_URL="https://worldchain.drpc.org"
+STRATEGY="0x313bA1D5D5AA1382a80BA839066A61d33C110489"
+KEYSTORE="solidity-labs-deployer"
+GAS_AMOUNT="0.002ether"
+SECRETS_FILE="$(dirname "$0")/../.harvester-wallet.json"
+
+# ── Step 1: Generate burner wallet ────────────────────────────────────────────
+
+echo "=== Step 1: Generating burner wallet ==="
+WALLET_OUTPUT=$(cast wallet new)
+BURNER_ADDRESS=$(echo "$WALLET_OUTPUT" | grep "Address:" | awk '{print $2}')
+BURNER_KEY=$(echo "$WALLET_OUTPUT" | grep "Private key:" | awk '{print $3}')
+
+echo "  Burner address:  $BURNER_ADDRESS"
+echo "  Burner key:      $BURNER_KEY"
+
+# Save to file BEFORE doing anything irreversible
+cat > "$SECRETS_FILE" <<EOF
+{
+  "address": "$BURNER_ADDRESS",
+  "privateKey": "$BURNER_KEY",
+  "createdAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "strategy": "$STRATEGY",
+  "chainId": 480
+}
+EOF
+chmod 600 "$SECRETS_FILE"
+echo "  Saved to: $SECRETS_FILE"
+echo ""
+
+# ── Step 2: Fund burner with ETH for gas ──────────────────────────────────────
+
+echo "=== Step 2: Funding burner with $GAS_AMOUNT ==="
+cast send "$BURNER_ADDRESS" \
+  --value "$GAS_AMOUNT" \
+  --rpc-url "$RPC_URL" \
+  --account "$KEYSTORE"
+
+BALANCE=$(cast balance "$BURNER_ADDRESS" --rpc-url "$RPC_URL" --ether)
+echo "  Burner balance: $BALANCE ETH"
+echo ""
+
+# ── Step 3: Transfer strategy ownership to burner ─────────────────────────────
+
+echo "=== Step 3: Transferring strategy ownership to burner ==="
+CURRENT_OWNER=$(cast call "$STRATEGY" "owner()(address)" --rpc-url "$RPC_URL")
+echo "  Current owner: $CURRENT_OWNER"
+
+cast send "$STRATEGY" \
+  "transferOwnership(address)" "$BURNER_ADDRESS" \
+  --rpc-url "$RPC_URL" \
+  --account "$KEYSTORE"
+
+NEW_OWNER=$(cast call "$STRATEGY" "owner()(address)" --rpc-url "$RPC_URL")
+echo "  New owner:     $NEW_OWNER"
+echo ""
+
+# ── Step 4: Verify ────────────────────────────────────────────────────────────
+
+echo "=== Verification ==="
+if [ "$(echo "$NEW_OWNER" | tr '[:upper:]' '[:lower:]')" = "$(echo "$BURNER_ADDRESS" | tr '[:upper:]' '[:lower:]')" ]; then
+  echo "  Ownership transfer: OK"
+else
+  echo "  ERROR: Ownership transfer failed!"
+  echo "  Expected: $BURNER_ADDRESS"
+  echo "  Got:      $NEW_OWNER"
+  exit 1
+fi
+
+echo ""
+echo "=== Done ==="
+echo ""
+echo "Set these in Vercel:"
+echo "  AGENT_PRIVATE_KEY=$BURNER_KEY"
+echo ""
+echo "Register with AgentKit:"
+echo "  npx @worldcoin/agentkit-cli register $BURNER_ADDRESS"


### PR DESCRIPTION
## Summary

- Standalone harvester agent in `/agent/` using `@worldcoin/agentkit` for human-backed identity verification
- `setup-harvester.sh` script to generate burner wallet, fund it, and transfer strategy ownership
- Harvest API route supports GET for Vercel cron (with `CRON_SECRET` bearer auth)
- Agent registered in AgentBook on World Chain: `0x39e1e01f4CB9B2FED78892aa378aB2baf0F759b9` ([tx](https://worldscan.org/tx/0x7af7c3c210fecd172bd20e85a4ac4cc96ef83a85f24a62066b86af7fd9974352))

## AgentKit integration

The agent uses `createAgentBookVerifier()` from `@worldcoin/agentkit` to verify on startup that the wallet is registered as human-backed in AgentBook. This is what makes us eligible for the **Best Use of AgentKit** prize track ($8K).

## Roadmap

- Permissionless harvesting: gate `harvest()` on-chain so any AgentBook-registered wallet can compound (#75)
- Role separation: dedicated harvester role instead of full ownership transfer

## Test plan

- [x] `setup-harvester.sh` ran successfully on World Chain mainnet
- [x] Strategy ownership verified: `cast call 0x313b... "owner()(address)"` returns burner
- [x] Agent registered in AgentBook via `agentkit-cli register`
- [x] `tsc --noEmit` passes in `/agent/`
- [ ] Manual `agent harvest` test (requires Merkl rewards to be accrued)

🤖 Generated with [Claude Code](https://claude.com/claude-code)