### PR TITLE
fix: observer mode only on desktop, copy button, v2.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ The `README.md` contains a `## Proof of Work` section that judges read to assess
 
 Specifically:
 - Add the new PR to the correct category table inside the `<details>` block (Infrastructure, Contracts, World ID, Permit2, Mini App, Agent, Features, Security)
-- Update the **Development Velocity** stats table: increment the merged PR count, update total commit count (`git log --oneline | wc -l`), and update the LOC count if significant code was added
+- Update the **Development Velocity** stats table: increment the merged PR count, update total commit count (`git log --oneline | wc -l`), and update the LOC count (`cloc contracts/src app/src agent/src --quiet | tail -3` — update the SUM code line)
 - If the PR closes an issue, move that issue from the **Roadmap** list to the **Completed** table
 - If a new category of work was introduced (e.g. a new area of the codebase), add a new category table inside `<details>`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,18 @@ When making changes to the product (scope, architecture, contracts, UI, demo), u
 | `agent/` | Harvester cron | Agent/harvester changes |
 | `README.md` | Repo README (mirrors pitch one-pager) | Any public-facing change |
 
+## README Proof of Work — Keep This Section Current
+
+The `README.md` contains a `## Proof of Work` section that judges read to assess effort. **Every time a PR is merged or a significant issue is resolved, update this section.**
+
+Specifically:
+- Add the new PR to the correct category table inside the `<details>` block (Infrastructure, Contracts, World ID, Permit2, Mini App, Agent, Features, Security)
+- Update the **Development Velocity** stats table: increment the merged PR count, update total commit count (`git log --oneline | wc -l`), and update the LOC count if significant code was added
+- If the PR closes an issue, move that issue from the **Roadmap** list to the **Completed** table
+- If a new category of work was introduced (e.g. a new area of the codebase), add a new category table inside `<details>`
+
+The commit count and PR count are the fastest way for judges to see work volume at a glance — keep them accurate.
+
 ## Key Design Decisions (DO NOT CHANGE without updating all files)
 
 1. **Shared vault, not per-user strategies** — one pool, proportional shares, one harvest benefits everyone

--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ This section exists for one reason: to show judges we went all-in.
 
 | Metric | Count |
 |--------|-------|
-| Total commits | **152** |
-| Merged pull requests | **92** |
+| Total commits | **160** |
+| Merged pull requests | **94** |
 | GitHub issues tracked | **90+** |
-| Lines of code (Solidity + TypeScript) | **2,809** |
+| Lines of code (Solidity + TypeScript) | **3,020** |
 | Build window | **36 hours** (ETHGlobal Cannes, Apr 3–5 2026) |
 
 [View commit frequency →](https://github.com/ElliotFriedman/harvest-world/graphs/commit-activity)
@@ -149,7 +149,7 @@ This section exists for one reason: to show judges we went all-in.
 ### Merged Pull Requests
 
 <details>
-<summary>92 merged PRs across 8 categories — click to expand</summary>
+<summary>94 merged PRs across 9 categories — click to expand</summary>
 
 #### Infrastructure & CI
 | PR | Description |
@@ -223,11 +223,19 @@ This section exists for one reason: to show judges we went all-in.
 |----|-------------|
 | [#91](https://github.com/ElliotFriedman/harvest-world/pull/91) | feat: integrate Uniswap Trading API for swap intelligence |
 | [#92](https://github.com/ElliotFriedman/harvest-world/pull/92) | feat: show streaming yield unlock countdown in agent status |
+| [#95](https://github.com/ElliotFriedman/harvest-world/pull/95) | feat: observer mode boot sequence, QR deeplink, 4 new terminal commands (gm, oracle, roots, scan) |
+
+#### Fixes & Polish
+| PR | Description |
+|----|-------------|
+| [#96](https://github.com/ElliotFriedman/harvest-world/pull/96) | fix: observer mode only on desktop (250ms MiniKit init delay), copy button, v2.5 |
 
 #### Security & Docs
 | PR | Description |
 |----|-------------|
 | [#86](https://github.com/ElliotFriedman/harvest-world/pull/86) | docs: internal security audit |
+| [#93](https://github.com/ElliotFriedman/harvest-world/pull/93) | docs: add README, CLAUDE.md, Claude skills config |
+| [#94](https://github.com/ElliotFriedman/harvest-world/pull/94) | docs: add Proof of Work section to README |
 
 </details>
 

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -116,18 +116,23 @@ export default function Terminal() {
   }, [lines]);
 
   useEffect(() => {
-    if (MiniKit.isInstalled()) {
-      if (MiniKit.user?.walletAddress) {
-        setWalletAddress(MiniKit.user.walletAddress);
+    // Delay MiniKit check — the webview needs ~250ms to initialize MiniKit
+    // before isInstalled() reliably returns true inside World App.
+    const timer = setTimeout(() => {
+      if (MiniKit.isInstalled()) {
+        if (MiniKit.user?.walletAddress) {
+          setWalletAddress(MiniKit.user.walletAddress);
+        }
+        setLines([
+          "HARVEST v2.4 — Agentic DeFi, for humans.",
+          "World Chain yield aggregator.",
+          "",
+        ]);
+      } else {
+        runObserverBoot();
       }
-      setLines([
-        "HARVEST v2.4 — Agentic DeFi, for humans.",
-        "World Chain yield aggregator.",
-        "",
-      ]);
-    } else {
-      runObserverBoot();
-    }
+    }, 250);
+    return () => clearTimeout(timer);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -165,35 +170,31 @@ export default function Terminal() {
   }
 
   async function runObserverBoot(): Promise<void> {
+    // Desktop-only boot — type at 55ms (30% slower than the in-app 42ms default)
+    const d = 55;
     await flicker();
-    await typewriterPrint("HARVEST OS v2.4");
+    await typewriterPrint("HARVEST OS v2.4", d);
     await new Promise((r) => setTimeout(r, 300));
-    await typewriterPrint("initializing...");
+    await typewriterPrint("initializing...", d);
     await new Promise((r) => setTimeout(r, 500));
     await flicker();
     setLines((prev) => [...prev, ""]);
-    await typewriterPrint("> checking World App... [not installed]");
+    await typewriterPrint("> checking World App... [not installed]", d);
     await new Promise((r) => setTimeout(r, 300));
-    await typewriterPrint("> falling back to observer mode");
+    await typewriterPrint("> falling back to observer mode", d);
     await new Promise((r) => setTimeout(r, 600));
     setLines((prev) => [...prev, ""]);
-    await typewriterPrint("This terminal runs inside World App.");
+    await typewriterPrint("This terminal runs inside World App.", d);
     await new Promise((r) => setTimeout(r, 200));
-    await typewriterPrint("You're seeing the outside.");
+    await typewriterPrint("You're seeing the outside.", d);
     await new Promise((r) => setTimeout(r, 600));
     await gentleFlicker();
     setLines((prev) => [...prev, ""]);
-    await typewriterPrint("The humans are inside, earning yield.");
+    await typewriterPrint("The humans are inside, earning yield.", d);
     await new Promise((r) => setTimeout(r, 200));
-    await typewriterPrint("Scan to join them.");
-    setLines((prev) => [
-      ...prev,
-      "",
-      "  open in World App:",
-      `  ${WORLD_APP_URL}`,
-      "",
-    ]);
-    await typewriterPrint("Type 'help' to explore. Type 'scan' for the deeplink.");
+    await typewriterPrint("Scan the QR to join them.", d);
+    setLines((prev) => [...prev, ""]);
+    await typewriterPrint("Type 'help' to explore.", d);
     setLines((prev) => [...prev, ""]);
     setIsObserverMode(true);
   }
@@ -1003,8 +1004,26 @@ export default function Terminal() {
                 fgColor="#00ff41"
               />
             </div>
-            <div style={{ fontSize: "9px", color: "#00ff41", opacity: 0.6, textAlign: "center", maxWidth: "160px" }}>
-              harvest.world // DeFi, for humans
+            <button
+              onClick={() => navigator.clipboard.writeText(WORLD_APP_URL)}
+              style={{
+                background: "transparent",
+                border: "1px solid #00ff41",
+                color: "#00ff41",
+                fontFamily: "inherit",
+                fontSize: "11px",
+                padding: "5px 12px",
+                cursor: "pointer",
+                letterSpacing: "0.05em",
+                width: "100%",
+              }}
+              onMouseEnter={(e) => { (e.target as HTMLButtonElement).style.background = "#00ff41"; (e.target as HTMLButtonElement).style.color = "#000"; }}
+              onMouseLeave={(e) => { (e.target as HTMLButtonElement).style.background = "transparent"; (e.target as HTMLButtonElement).style.color = "#00ff41"; }}
+            >
+              [ copy link ]
+            </button>
+            <div style={{ fontSize: "9px", color: "#00ff41", opacity: 0.5, textAlign: "center", maxWidth: "160px" }}>
+              harvest // DeFi, for humans
             </div>
           </div>
         </>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -124,7 +124,7 @@ export default function Terminal() {
           setWalletAddress(MiniKit.user.walletAddress);
         }
         setLines([
-          "HARVEST v2.4 — Agentic DeFi, for humans.",
+          "HARVEST v2.5 — Agentic DeFi, for humans.",
           "World Chain yield aggregator.",
           "",
         ]);
@@ -173,7 +173,7 @@ export default function Terminal() {
     // Desktop-only boot — type at 55ms (30% slower than the in-app 42ms default)
     const d = 55;
     await flicker();
-    await typewriterPrint("HARVEST OS v2.4", d);
+    await typewriterPrint("HARVEST OS v2.5", d);
     await new Promise((r) => setTimeout(r, 300));
     await typewriterPrint("initializing...", d);
     await new Promise((r) => setTimeout(r, 500));


### PR DESCRIPTION
## Summary

- **Fix observer mode triggering in World App** — `MiniKit.isInstalled()` was called synchronously on mount before the World App webview had time to initialize, so it returned `false` even when inside World App. Fixed by wrapping the check in a 250ms `setTimeout` — two clear paths now:
  - **Mobile / World App** → normal terminal (`HARVEST v2.5`, `get started` button)
  - **Desktop / browser** → animated observer mode boot sequence + QR code
- **Desktop-only typing speed** — observer boot sequence uses 55ms/char (~30% slower than the in-app 42ms default). Mobile typing speed unchanged.
- **Remove long URL from boot text** — the QR code + copy button handle it; printing a 100-char URL to the terminal looked broken on mobile
- **[ copy link ] button** in QR panel with green hover invert effect
- **Version bump** v2.4 → v2.5

## Test plan

- [ ] Open in World App on mobile — should show normal `HARVEST v2.5` startup, NOT observer mode
- [ ] Open URL in desktop browser — should show observer boot sequence with QR + copy button
- [ ] `[ copy link ]` copies the full World App deeplink to clipboard
- [ ] In-app commands (`gm`, `oracle`, etc.) type at normal speed; desktop boot sequence types noticeably slower

🤖 Generated with [Claude Code](https://claude.com/claude-code)