### PR TITLE
docs: break out LOC by language in Proof of Work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ The `README.md` contains a `## Proof of Work` section that judges read to assess
 
 Specifically:
 - Add the new PR to the correct category table inside the `<details>` block (Infrastructure, Contracts, World ID, Permit2, Mini App, Agent, Features, Security)
-- Update the **Development Velocity** stats table: increment the merged PR count, update total commit count (`git log --oneline | wc -l`), and update the LOC count (`cloc contracts/src app/src agent/src --quiet | tail -3` — update the SUM code line)
+- Update the **Development Velocity** stats table: increment the merged PR count, update total commit count (`git log --oneline | wc -l`), and update the LOC breakdown (`cloc . --exclude-dir=node_modules,lib,.git,broadcast,cache,out,dist,.next --quiet | tail -15` — update Solidity, TypeScript, Markdown, and full repo totals)
 - If the PR closes an issue, move that issue from the **Roadmap** list to the **Completed** table
 - If a new category of work was introduced (e.g. a new area of the codebase), add a new category table inside `<details>`
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ This section exists for one reason: to show judges we went all-in.
 | Total commits | **160** |
 | Merged pull requests | **94** |
 | GitHub issues tracked | **90+** |
-| Lines of code (Solidity + TypeScript) | **3,020** |
+| Solidity (28 files) | **2,175 lines** |
+| TypeScript (17 files) | **1,807 lines** |
+| Documentation (14 files) | **11,332 lines** |
+| Full repo (excl. dependencies) | **~19,400 lines** |
 | Build window | **36 hours** (ETHGlobal Cannes, Apr 3–5 2026) |
 
 [View commit frequency →](https://github.com/ElliotFriedman/harvest-world/graphs/commit-activity)


### PR DESCRIPTION
## Summary

Replaces the single `3,020 lines` stat (which only counted `src/` directories) with the real full-repo breakdown:

| Language | Lines |
|----------|-------|
| Solidity (28 files) | 2,175 |
| TypeScript (17 files) | 1,807 |
| Documentation (14 files) | 11,332 |
| **Full repo (excl. deps)** | **~19,400** |

The 3,020 figure was just `contracts/src + app/src + agent/src`. The documentation number is large because the spec, technical design, pitch, security audit, root cause analysis, and Certora README are all substantive documents — worth showing.

Also updates the `cloc` command in CLAUDE.md to use the full breakdown going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)