### PR TITLE
fix: restore working Certora report URLs, fix invariant base case

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ We wrote Certora Prover specs (CVL2) for the 3 core contracts. Formal verificati
 
 | Contract | Spec | Passing | Dashboard |
 |----------|------|---------|-----------|
-| `BeefyVaultV7` | `certora/specs/BeefyVaultV7.spec` | **15/15** | [Certora Report](https://prover.certora.com/output/651303/555fa8a141fe4d66a89f42ff4f3c3fa7) |
-| `BaseAllToNativeFactoryStrat` | `certora/specs/BaseStrategy.spec` | **10/10** | [Certora Report](https://prover.certora.com/output/651303/e0dcd216e12045a89c7ae1f0ea20aa06) |
+| `BeefyVaultV7` | `certora/specs/BeefyVaultV7.spec` | **15/15** | [Certora Report](https://prover.certora.com/output/651303/496832330da84903aebb2e06001116bd?anonymousKey=e0cc398a4f028ec7d493cbdbf5c4938ad2a6fb6e) |
+| `BaseAllToNativeFactoryStrat` | `certora/specs/BaseStrategy.spec` | **10/10** | [Certora Report](https://prover.certora.com/output/651303/96851137a8f04b30a2b5a2aa845711a8?anonymousKey=bf48592a43f3083fe687d9db12f2971fb14ff264) |
 | `StrategyMorphoMerkl` | `certora/specs/StrategyMorphoMerkl.spec` | **5/5** | |
 
 Key properties proven: share minting/burning correctness, deposit-withdraw round-trip safety, price-per-share monotonicity under yield, locked profit decay, manager/owner access control, reward token safety.

--- a/contracts/certora/specs/StrategyMorphoMerkl.spec
+++ b/contracts/certora/specs/StrategyMorphoMerkl.spec
@@ -149,24 +149,14 @@ ghost mathint ghostStrategyMorphoShares {
 }
 
 // =============================================================================
-// INITIALIZATION INVARIANT
+// INITIALIZATION HELPERS
 //
 // StrategyMorphoMerkl inherits OwnableUpgradeable.  Before initialize(),
 // owner==0 and vault==0, creating spurious counterexamples for access-control
-// and accounting rules.
-//
-// We prove strategyInitialized() inductively and require it in all rules.
-// requireInvariant is sound: the prover uses the already-proven invariant.
+// and accounting rules.  We require initialization in each rule directly
+// (upgradeable constructors leave storage zeroed, so an invariant's base case
+// would fail).
 // =============================================================================
-
-invariant strategyInitialized()
-    strat.currentOwner() != 0 && strat.vault() != 0
-    {
-        preserved {
-            require strat.currentOwner() != 0;
-            require strat.vault() != 0;
-        }
-    }
 
 // =============================================================================
 // INVARIANTS
@@ -194,9 +184,10 @@ invariant strategyInitialized()
 // rewards are permanently unclaimed.
 // -----------------------------------------------------------------------------
 rule setClaimerUpdatesStorage(address newClaimer) {
-    requireInvariant strategyInitialized();
     env e;
 
+    require strat.currentOwner() != 0;
+    require strat.vault() != 0;
     address mgr = strat.currentOwner();
     require e.msg.sender == mgr;
     require newClaimer != 0;
@@ -222,7 +213,8 @@ rule setClaimerUpdatesStorage(address newClaimer) {
 // incorrectly — potentially draining the strategy's share position.
 // -----------------------------------------------------------------------------
 rule cannotAddMorphoVaultAsReward() {
-    requireInvariant strategyInitialized();
+    require strat.currentOwner() != 0;
+    require strat.vault() != 0;
     env e;
 
     require strat.morphoVault() == morpho;
@@ -249,7 +241,8 @@ rule cannotAddMorphoVaultAsReward() {
 // reducing deposits on every harvest.
 // -----------------------------------------------------------------------------
 rule cannotAddWantAsReward() {
-    requireInvariant strategyInitialized();
+    require strat.currentOwner() != 0;
+    require strat.vault() != 0;
     env e;
 
     require strat.morphoVault() == morpho;
@@ -275,7 +268,8 @@ rule cannotAddWantAsReward() {
 // Adding it as a reward would cause double-counting in _swapRewardsToNative().
 // -----------------------------------------------------------------------------
 rule cannotAddNativeAsReward() {
-    requireInvariant strategyInitialized();
+    require strat.currentOwner() != 0;
+    require strat.vault() != 0;
     env e;
 
     require strat.morphoVault() == morpho;


### PR DESCRIPTION
Reverted report URLs to original anonymousKey links that are publicly accessible. Fixed strategyInitialized invariant failing at constructor base case by converting to per-rule requires (upgradeable contracts start with owner=vault=0).